### PR TITLE
Adds repo-level dev stats, authenticates github api requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ USE contributors;
 
 This script fetches data from the GitHub API and stores it in the database.
 
-3. (Optional) run script to output tables into csv files. 
+3. (Optional) run the export script to output tables into csv files. 
 
 ```python3 csv_export.py```
+
+4. (Optional) run the dev stats script to generate baseic repo-level statistsics (# commits, additions, deletions, total lines changed).
+
+```python3 dev_stats.py```

--- a/contributors.py
+++ b/contributors.py
@@ -7,9 +7,7 @@ before_list = []
 feb_list = []
 
 for b in a:
-    #print(b['github_username'])
-    #c = session.execute('SELECT * FROM event_log WHERE datetime <  "2019-01-01" and github_username = "'+b['github_username']+'";')
-    #print(b[0])
+
     feb_list.append(b[0])
     c = session.execute('SELECT * FROM event_log WHERE datetime <  "2019-02-01" and github_username = "'+str(b[0])+'" and type_id = 1;')
     #print(b)

--- a/contributors.py
+++ b/contributors.py
@@ -1,0 +1,29 @@
+from database import Base, engine, session
+import csv
+
+a = session.execute('SELECT DISTINCT github_username FROM event_log WHERE datetime >  "2019-02-01" and datetime < "2019-02-28" and type_id = 1;')
+
+before_list = []
+feb_list = []
+
+for b in a:
+    #print(b['github_username'])
+    #c = session.execute('SELECT * FROM event_log WHERE datetime <  "2019-01-01" and github_username = "'+b['github_username']+'";')
+    #print(b[0])
+    feb_list.append(b[0])
+    c = session.execute('SELECT * FROM event_log WHERE datetime <  "2019-02-01" and github_username = "'+str(b[0])+'" and type_id = 1;')
+    #print(b)
+    for d in c:
+        print(d['github_username'])
+        before_list.append(d['github_username'])
+
+
+before_list = list(set(before_list))
+
+print(before_list)
+print(feb_list)
+
+
+temp3 = [x for x in feb_list if x not in before_list]
+
+print(temp3) 

--- a/dev_stats.py
+++ b/dev_stats.py
@@ -1,0 +1,99 @@
+from database import Base, engine, session
+import csv
+from functions import *
+
+# Get list of repositories in database
+r = session.execute('SELECT * FROM repository_list;') 
+
+additions_total = 0
+deletions_total = 0
+
+repos = []
+open_prs = []
+additions_v = []
+deletions_v = []
+open_prs_v = []
+commits_v = []
+
+list_of_repos = ['dcrdocs']
+
+for repo in r:
+# for repo in list_of_repos:
+
+	# print(repo["name"])
+	# print(repo["id"])
+
+	repos.append(repo["name"])
+	# repos.append(repo)
+
+	check_limit_wait(token) # Check to see if over API rate limit
+	# fetch commits
+	c = session.query(Event).filter(Event.type_id==1, Event.repo_id==repo["id"], Event.datetime >  "2019-03-01", Event.datetime < "2019-04-01").all()  
+	# c = session.query(Event).filter(Event.type_id==1, Event.repo_id==1, Event.datetime >=  "2019-03-01", Event.datetime <= "2019-04-01").all()  
+
+	additions = 0
+	deletions = 0
+	commits = 0
+
+	for commit in c:
+
+		# Fetch commit from github from commit hash
+		commit_hash = pickle.loads(commit.data)["sha"] 
+		commit = requests.get("https://api.github.com/repos/"+username+"/"+repo["name"]+"/commits/"+commit_hash, auth=(username,token))
+		# commit = requests.get("https://api.github.com/repos/"+username+"/"+repo+"/commits/"+commit_hash, auth=(username,token))
+
+		additions += commit.json()['stats']['additions']  
+		deletions += commit.json()['stats']['deletions'] 
+		commits += 1
+
+	# print(repo["name"])
+	print(repo)
+	print("additions: " + str(additions))
+	print("deletions: " + str(deletions))
+
+	additions_v.append(additions)
+	deletions_v.append(deletions)
+	commits_v.append(commits)
+
+	additions_total += additions
+	deletions_total += deletions 
+
+
+	# fetch open PRs
+	check_limit_wait(token) # Check to see if over API rate limit
+	p = session.query(Event).filter(Event.type_id==3, Event.repo_id==repo["id"], Event.datetime >=  "2019-03-01", Event.datetime <= "2019-04-01").all()  
+	# p = session.query(Event).filter(Event.type_id==3, Event.repo_id==1, Event.datetime >=  "2019-03-01", Event.datetime <= "2019-03-31").all() 
+
+	open_prs = 0
+
+	for pr in p:
+		pull_request = pickle.loads(pr.data)
+		# print(pull_request['state'])
+		print(state)
+		if pull_request['state'] == 'open':
+			open_prs += 1
+
+	open_prs_v.append(open_prs)
+
+print(repo)
+
+
+
+i = 0
+
+for i in range(len(repos)):
+# for repo in r:
+
+	print("repo: "+ repos[i])
+	print("additions: " + str(additions_v[i]))
+	print("deletions: " + str(deletions_v[i]))
+	print("total changes: " + str(additions_v[i]+deletions_v[i]))
+	print("commits master: " + str(commits_v[i]))
+	print("open PRs: " + str(open_prs_v[i])+"\n")
+	
+
+
+
+
+
+

--- a/dev_stats.py
+++ b/dev_stats.py
@@ -18,10 +18,6 @@ commits_v = []
 list_of_repos = ['dcrdocs']
 
 for repo in r:
-# for repo in list_of_repos:
-
-	# print(repo["name"])
-	# print(repo["id"])
 
 	repos.append(repo["name"])
 	# repos.append(repo)
@@ -78,11 +74,9 @@ for repo in r:
 print(repo)
 
 
-
 i = 0
 
 for i in range(len(repos)):
-# for repo in r:
 
 	print("repo: "+ repos[i])
 	print("additions: " + str(additions_v[i]))

--- a/dev_stats.py
+++ b/dev_stats.py
@@ -1,6 +1,7 @@
 from database import Base, engine, session
 import csv
 from functions import *
+from main import *
 
 # Get list of repositories in database
 r = session.execute('SELECT * FROM repository_list;') 
@@ -75,6 +76,8 @@ print(repo)
 
 
 i = 0
+total_additions = 0
+total_deletions = 0
 
 for i in range(len(repos)):
 
@@ -84,7 +87,12 @@ for i in range(len(repos)):
 	print("total changes: " + str(additions_v[i]+deletions_v[i]))
 	print("commits master: " + str(commits_v[i]))
 	print("open PRs: " + str(open_prs_v[i])+"\n")
-	
+
+	total_additions += additions_v[i]
+	total_deletions += deletions_v[i]
+
+print("total additions (all repos): " + str(total_additions))
+print("total deletions (all repos): " + str(total_deletions))
 
 
 

--- a/event_log.csv
+++ b/event_log.csv
@@ -1,1327 +1,2642 @@
-1,1,1,Marco Peereboom,2019-01-16 20:00:39,https://github.com/decred/politeia/commit/268d6c8bbba90292b923188f6a82bcbe636d6ee1
-2,1,1,orthomind,2019-01-14 03:33:29,https://github.com/decred/politeia/commit/793ab1b7b1e95f7d625b3e0daf4e3587fecd1d67
-3,1,1,Everton Melo,2019-01-04 21:52:05,https://github.com/decred/politeia/commit/8cdcda2aef9d9d1ba3ccad9d7d4891e382444001
-4,1,1,David Hill,2019-01-02 15:31:41,https://github.com/decred/politeia/commit/3b7271edd42beab70a2be4db19bd6e4abe0a6368
-5,1,1,Thiago de Freitas Figueiredo,2018-12-31 12:17:44,https://github.com/decred/politeia/commit/a56b26227c08ec70eb78ee3879812a5b856c38c6
-6,1,1,lukebp,2018-12-20 16:29:08,https://github.com/decred/politeia/commit/8624e18eb9e678a9a1642fb4f51fa425def6775a
-7,1,1,lukebp,2018-12-20 16:28:44,https://github.com/decred/politeia/commit/5bfb21ffba6c5f06866f74cb0e48e129ede19dc6
-8,1,1,David Hill,2018-12-18 16:34:26,https://github.com/decred/politeia/commit/2eeea9db91b6d69d5818ddf5cdb0253db48bd072
-9,1,1,David Hill,2018-12-18 15:21:41,https://github.com/decred/politeia/commit/8afafff882cb0459e6c28abcbd885eedaf98d642
-10,1,1,tpkeeper,2018-12-18 15:17:29,https://github.com/decred/politeia/commit/7347a032e7916adbd614d349596cc61fa2e69ce2
-11,1,1,Seth Benton,2018-12-13 23:24:40,https://github.com/decred/politeia/commit/c6b0be997e878b288cc9636d34e970ff950b0be4
-12,1,1,David Hill,2018-12-13 21:22:24,https://github.com/decred/politeia/commit/702966d99cbb4514fd6befe216941536e9ba37eb
-13,1,1,Thiago de Freitas Figueiredo,2018-12-13 21:20:00,https://github.com/decred/politeia/commit/0ebf83bb701f3e8d5e48ab6f6de3e3f2d9feee5a
-14,1,1,Fernando Abolafio,2018-12-10 15:40:38,https://github.com/decred/politeia/commit/f13e494415aa6553be9d965e5b05a1fbc8475284
-15,1,1,Thiago de Freitas Figueiredo,2018-12-09 23:07:40,https://github.com/decred/politeia/commit/5b4b3d0bfba6bdb736e2e43ad2996ef8a191f38d
-16,1,1,Dave Collins,2018-12-07 22:06:53,https://github.com/decred/politeia/commit/4bb033a75b45fe7453d89305228e6117c72bf1d4
-17,1,1,lukebp,2018-12-07 21:56:56,https://github.com/decred/politeia/commit/d6f18d31d15780e5f36feac45d1e62d3e31c3bbc
-18,1,1,Marco Peereboom,2018-12-07 16:02:12,https://github.com/decred/politeia/commit/ca4cdf83f0ee5248f24940f77b8c56246c5ce508
-19,1,1,Kevin,2018-12-07 11:57:06,https://github.com/decred/politeia/commit/df92852ee6a6763347a10403a85cf3abe50dc1f2
-20,1,1,Kevin,2018-12-03 19:21:35,https://github.com/decred/politeia/commit/73e375d3d3a498d0367089e7caa4dfad4fc6178b
-21,1,1,Fernando Abolafio,2018-12-03 14:49:31,https://github.com/decred/politeia/commit/fe4e341ce046d51fe0eb0349f0e4aa3e2097b0cd
-22,1,1,Thiago de Freitas Figueiredo,2018-12-01 12:18:14,https://github.com/decred/politeia/commit/ae149f59921240a657f80b04776f4ddf646c37ff
-23,1,1,Seth Benton,2018-11-30 22:24:42,https://github.com/decred/politeia/commit/ca9879763259d7c2f79be578a9dbd4054b5a464b
-24,1,1,Victor Guedes,2018-11-30 21:20:24,https://github.com/decred/politeia/commit/d057a8aad8b5d77b60515e264624ce6ca3e3a887
-25,1,1,lukebp,2018-11-30 14:34:55,https://github.com/decred/politeia/commit/12aeb5b6ec6a1a29a8812d7f0eaf1ae53f6b1551
-26,1,1,lukebp,2018-11-30 13:57:33,https://github.com/decred/politeia/commit/6f219dcc4938ab67e27450bfc6fdc1c699c023fb
-27,1,1,lukebp,2018-11-30 13:52:29,https://github.com/decred/politeia/commit/8eaa6745760d835255212a65c19b6b2b8375de0e
-28,1,1,Thiago de Freitas Figueiredo,2018-11-30 13:51:37,https://github.com/decred/politeia/commit/f5b4f10bcb7d7fd6da36232d268a13a93925f81d
-29,1,1,lukebp,2018-11-30 13:48:10,https://github.com/decred/politeia/commit/5895a1394f7301e26b7416c4bf178c7369892981
-30,1,1,Fernando Abolafio,2018-11-29 21:08:29,https://github.com/decred/politeia/commit/b9d34d285f5eb008702c8a9e1ce146c502653ec0
-31,1,1,David Hill,2018-11-29 17:14:20,https://github.com/decred/politeia/commit/449d9c09f432f10902b0833755666bacf83d57e3
-32,1,1,Sean Durkin,2018-11-27 14:17:45,https://github.com/decred/politeia/commit/bf36bad02071753b78577d572678a43d84461f82
-33,1,1,lukebp,2018-11-19 18:18:48,https://github.com/decred/politeia/commit/3a7c386f4c726137bc67bae3f00386bde7d92287
-34,1,1,lukebp,2018-11-16 20:30:28,https://github.com/decred/politeia/commit/cc17ab6f49795e3b3035b439df74f2db6fc49079
-35,1,1,Sean Durkin,2018-11-15 16:22:31,https://github.com/decred/politeia/commit/a5ff2a88faacfa436ebcd9feaae4415db56ea54e
-36,1,1,David Hill,2018-11-14 18:08:58,https://github.com/decred/politeia/commit/12f7378558c1752ccdc3cf7f1a70109a1f18b120
-37,1,1,Tiago Alves Dulce,2018-11-14 14:42:31,https://github.com/decred/politeia/commit/c36457e458b3419b755f6d2fa5fd3c9d1e1f595a
-38,1,1,Fernando Abolafio,2018-11-14 14:22:46,https://github.com/decred/politeia/commit/4a8c7e5f207ee8b8f7f7efd5f8f260bb3a894458
-39,1,1,Fernando Abolafio,2018-11-13 14:47:20,https://github.com/decred/politeia/commit/6d7eb9834b060be02ac5ca5f250dae2c52e7e4ac
-40,1,1,lukebp,2018-11-09 16:16:52,https://github.com/decred/politeia/commit/595137dd542ab1af0df39053243465d862266e74
-41,1,1,degeri,2018-11-09 15:11:38,https://github.com/decred/politeia/commit/f66e5be1b767e572458059acde6eff0b302bcd79
-42,1,1,lukebp,2018-11-09 15:05:07,https://github.com/decred/politeia/commit/3fcf1fb0884d8ff259c810408c59c10d66f83329
-43,1,1,Fernando Abolafio,2018-11-06 14:08:57,https://github.com/decred/politeia/commit/61f5f8c4e569e3730ae3dfad4c427b8d2d40d6ee
-44,1,1,lukebp,2018-11-04 00:18:40,https://github.com/decred/politeia/commit/5ba517958a145e693c17dc807ed775dd2251777c
-45,1,1,David Hill,2018-11-01 22:41:45,https://github.com/decred/politeia/commit/f91cb149b04de6e7a942dd3fab2848ce5ad2bb8c
-46,1,1,lukebp,2018-11-01 19:59:57,https://github.com/decred/politeia/commit/7697cd02e05b76cf7782e2d952fe0e833a384a9d
-47,1,1,David Hill,2018-11-01 14:17:58,https://github.com/decred/politeia/commit/7a469b90c282ffaaa34af0804b3a92c67297a5c6
-48,1,1,Marco Peereboom,2018-10-31 20:57:32,https://github.com/decred/politeia/commit/9a765f875895bbc78e0eec0dd4d38d80cb7fcdee
-49,1,1,Fernando Abolafio,2018-10-31 13:30:20,https://github.com/decred/politeia/commit/b9e5d8a9a4a97e67cf2b1514839fd4b1708919c5
-50,1,1,Marco Peereboom,2018-10-25 20:23:10,https://github.com/decred/politeia/commit/652443ae5d247f7f4e33c9cce8a1f01d87cf3e14
-51,1,1,Sean Durkin,2018-10-23 19:38:45,https://github.com/decred/politeia/commit/7c2d6e0f82e8770ab7748d174f8cafc9fa5277ff
-52,1,1,Mawueli Kofi Adzoe,2018-10-23 18:50:26,https://github.com/decred/politeia/commit/435fe5c078f5986b73a3c17452b4013d3481edb4
-53,1,1,lukebp,2018-10-23 18:48:27,https://github.com/decred/politeia/commit/afeecd0181a0c46305c4c5917d90060a18d47b24
-54,1,1,VcTT,2018-10-23 13:24:02,https://github.com/decred/politeia/commit/42be2de0c8ba14dbedfdcf5ab70fcb153bfb7f75
-55,1,1,Fernando Abolafio,2018-10-22 18:05:16,https://github.com/decred/politeia/commit/2f360bee12b33d20aa2d75deef7d70254bd4d27c
-56,1,1,lukebp,2018-10-22 15:36:43,https://github.com/decred/politeia/commit/de5a779a76875471fcaf3d0d4661c7e057c2d5dd
-57,1,1,Sean Durkin,2018-10-21 21:16:21,https://github.com/decred/politeia/commit/9b90ffa5a6b54d8a72ea5599c67c57b7e7947e36
-58,1,1,lukebp,2018-10-19 20:06:49,https://github.com/decred/politeia/commit/8ce48ad4a1e96c045335eaef3105eb9ce1cb0711
-59,1,1,Sean Durkin,2018-10-18 15:29:16,https://github.com/decred/politeia/commit/f63e36f4f58ec9d08f088d2ad6303aaa74d389eb
-60,1,1,Sean Durkin,2018-10-18 15:02:40,https://github.com/decred/politeia/commit/7dae64e194ce416db087e0107e04ae0a335a89f0
-61,1,1,Marco Peereboom,2018-10-17 20:39:31,https://github.com/decred/politeia/commit/98481e9ffa0f17b5ca3ea392040c4fbe26eaaf38
-62,1,1,Sean Durkin,2018-10-17 19:25:11,https://github.com/decred/politeia/commit/b4f7d5d08bb33e0a86fd73fb37c8e61eb551af2e
-63,1,1,Sean Durkin,2018-10-17 15:59:59,https://github.com/decred/politeia/commit/23ff40ca9afc60b7942fa7612dc3cb390d8268f0
-64,1,1,Fernando Abolafio,2018-10-17 15:59:21,https://github.com/decred/politeia/commit/5229365a201e7eb3d76887eacad44bf86774a559
-65,1,1,Sean Durkin,2018-10-17 15:44:09,https://github.com/decred/politeia/commit/10598e3c2722b24ac219be4d69a216b27a301ce2
-66,1,1,Marco Peereboom,2018-10-17 15:43:10,https://github.com/decred/politeia/commit/908b2cc7a753ba670ed326ae51dd7d20c0875d18
-67,1,1,Sean Durkin,2018-10-17 14:22:35,https://github.com/decred/politeia/commit/0158643b6e704444d72cae14c2c8b659aac96fbd
-68,1,1,lukebp,2018-10-16 11:56:52,https://github.com/decred/politeia/commit/9f9149dbf2aa39839010cd6249827e7a68b8675c
-69,1,1,Marco Peereboom,2018-10-15 21:21:19,https://github.com/decred/politeia/commit/4cd2f3bb550914e955afbc44585a13c5aa417975
-70,1,1,Fernando Abolafio,2018-10-15 20:27:33,https://github.com/decred/politeia/commit/d9bc6c41ac3a856e7e342a4326dd6f271c572d2a
-71,1,1,Marco Peereboom,2018-10-15 20:20:04,https://github.com/decred/politeia/commit/567bd319d2f4287a4f093c0daeb9bf4dd1095d10
-72,1,1,Tiago Alves Dulce,2018-10-15 18:16:12,https://github.com/decred/politeia/commit/77bdc6c0c23d895a06df4767696cbfd8a4ffd158
-73,1,1,Marco Peereboom,2018-10-15 18:15:08,https://github.com/decred/politeia/commit/72d147f52dea2723d3f7ee0082144a8183cf722c
-74,1,1,Fernando Abolafio,2018-10-15 17:27:33,https://github.com/decred/politeia/commit/369c42e159f1125e0ce1107435cb1a989998d64b
-75,1,1,lukebp,2018-10-15 15:40:09,https://github.com/decred/politeia/commit/498ef3b79e3b3546d725ed6887214bd6e971e61a
-76,1,1,Marco Peereboom,2018-10-12 17:54:30,https://github.com/decred/politeia/commit/5a88ae0a6619503a91314ba40831bb3a11e19dc4
-77,1,1,Marco Peereboom,2018-10-09 14:53:46,https://github.com/decred/politeia/commit/da69903f25d4474baed325c64ff668f60e70a7ad
-78,1,1,lukebp,2018-10-09 14:41:42,https://github.com/decred/politeia/commit/7bbb0871ed2ac5030615e24629108f229617cbec
-79,1,1,Marco Peereboom,2018-10-05 20:17:26,https://github.com/decred/politeia/commit/8fdc8395b1b3c851c8b351778f14fbdbd83f78b8
-80,1,1,David Hill,2018-10-05 14:45:20,https://github.com/decred/politeia/commit/0a3a75ba7481a6d62950003caae4a34ecf73d367
-81,1,1,Fernando Abolafio,2018-10-05 13:31:49,https://github.com/decred/politeia/commit/1a8c9421cac2e1257ebec16d52001aa0a483a148
-82,1,1,lukebp,2018-10-04 17:51:21,https://github.com/decred/politeia/commit/500d4f8cb73bbb33fc60f565c444fff14f5b4501
-83,1,1,lukebp,2018-10-03 17:11:10,https://github.com/decred/politeia/commit/fe3510d73cc607af06d47e155e59fae041824991
-84,1,1,Tiago Alves Dulce,2018-10-03 15:32:28,https://github.com/decred/politeia/commit/ec0bed452cef859d4596c83fb2e180c7b6b7900a
-85,1,1,Fernando Abolafio,2018-10-02 15:58:55,https://github.com/decred/politeia/commit/08f854c6877fdc98bc91560bd4bbb56661cfa686
-86,1,1,Marco Peereboom,2018-10-01 15:50:15,https://github.com/decred/politeia/commit/c3217fd27d1b966defc79201c0d90764cbba64ff
-87,1,1,Marco Peereboom,2018-09-28 13:26:23,https://github.com/decred/politeia/commit/2b184624aa7880cf729488d3b0b727dac9c3424c
-88,1,1,Thiago de Freitas Figueiredo,2018-09-27 14:15:43,https://github.com/decred/politeia/commit/55e6706959765422d01818983777047a5ec18893
-89,1,1,Marco Peereboom,2018-09-26 22:34:08,https://github.com/decred/politeia/commit/f4c075780bed786a1faebe29b1692512dbe44b36
-90,1,1,lukebp,2018-09-26 20:48:53,https://github.com/decred/politeia/commit/edd35ad8aca0cd6e833355ed9ca3f910ad80f2c0
-91,1,1,lukebp,2018-09-26 20:43:06,https://github.com/decred/politeia/commit/be702439e795a8e18cd82dd2c701a495c80fdba0
-92,1,1,lukebp,2018-09-26 20:42:26,https://github.com/decred/politeia/commit/ccf106088ce0372efd9ea097153528ee92788db5
-93,1,1,Fernando Abolafio,2018-09-25 17:15:21,https://github.com/decred/politeia/commit/2ad0e1d5da0d5d37d4423ab011efee043df5772b
-94,1,1,lukebp,2018-09-25 13:59:13,https://github.com/decred/politeia/commit/6a514bb271c324ab25f9bbe0b204727c6de7dc1f
-95,1,1,lukebp,2018-09-25 13:55:56,https://github.com/decred/politeia/commit/8df6ae6c9c079df6499ac25ccb1be2c9394851b0
-96,1,1,lukebp,2018-09-19 20:56:06,https://github.com/decred/politeia/commit/2729f77d1727ab21bdb043866c51f330e5e5833e
-97,1,1,lukebp,2018-09-18 21:44:24,https://github.com/decred/politeia/commit/714024a05ed9cc4d43b7da92c8744931f91d33b7
-98,1,1,lukebp,2018-09-18 16:01:44,https://github.com/decred/politeia/commit/f0622b64920f1be163964be4e46e0da1547016bf
-99,1,1,lukebp,2018-09-17 21:12:02,https://github.com/decred/politeia/commit/b395e01336dfd86d430b30fd4a50c6033b65e6a3
-100,1,1,lukebp,2018-09-11 20:03:14,https://github.com/decred/politeia/commit/52f2c7d6e11b90d710ac4fa4a4079ca933de46bb
-101,1,1,Marco Peereboom,2019-01-16 20:00:39,https://github.com/decred/politeia/commit/268d6c8bbba90292b923188f6a82bcbe636d6ee1
-102,1,1,orthomind,2019-01-14 03:33:29,https://github.com/decred/politeia/commit/793ab1b7b1e95f7d625b3e0daf4e3587fecd1d67
-103,1,1,Everton Melo,2019-01-04 21:52:05,https://github.com/decred/politeia/commit/8cdcda2aef9d9d1ba3ccad9d7d4891e382444001
-104,1,1,David Hill,2019-01-02 15:31:41,https://github.com/decred/politeia/commit/3b7271edd42beab70a2be4db19bd6e4abe0a6368
-105,1,1,Thiago de Freitas Figueiredo,2018-12-31 12:17:44,https://github.com/decred/politeia/commit/a56b26227c08ec70eb78ee3879812a5b856c38c6
-106,1,1,lukebp,2018-12-20 16:29:08,https://github.com/decred/politeia/commit/8624e18eb9e678a9a1642fb4f51fa425def6775a
-107,1,1,lukebp,2018-12-20 16:28:44,https://github.com/decred/politeia/commit/5bfb21ffba6c5f06866f74cb0e48e129ede19dc6
-108,1,1,David Hill,2018-12-18 16:34:26,https://github.com/decred/politeia/commit/2eeea9db91b6d69d5818ddf5cdb0253db48bd072
-109,1,1,David Hill,2018-12-18 15:21:41,https://github.com/decred/politeia/commit/8afafff882cb0459e6c28abcbd885eedaf98d642
-110,1,1,tpkeeper,2018-12-18 15:17:29,https://github.com/decred/politeia/commit/7347a032e7916adbd614d349596cc61fa2e69ce2
-111,1,1,Seth Benton,2018-12-13 23:24:40,https://github.com/decred/politeia/commit/c6b0be997e878b288cc9636d34e970ff950b0be4
-112,1,1,David Hill,2018-12-13 21:22:24,https://github.com/decred/politeia/commit/702966d99cbb4514fd6befe216941536e9ba37eb
-113,1,1,Thiago de Freitas Figueiredo,2018-12-13 21:20:00,https://github.com/decred/politeia/commit/0ebf83bb701f3e8d5e48ab6f6de3e3f2d9feee5a
-114,1,1,Fernando Abolafio,2018-12-10 15:40:38,https://github.com/decred/politeia/commit/f13e494415aa6553be9d965e5b05a1fbc8475284
-115,1,1,Thiago de Freitas Figueiredo,2018-12-09 23:07:40,https://github.com/decred/politeia/commit/5b4b3d0bfba6bdb736e2e43ad2996ef8a191f38d
-116,1,1,Dave Collins,2018-12-07 22:06:53,https://github.com/decred/politeia/commit/4bb033a75b45fe7453d89305228e6117c72bf1d4
-117,1,1,lukebp,2018-12-07 21:56:56,https://github.com/decred/politeia/commit/d6f18d31d15780e5f36feac45d1e62d3e31c3bbc
-118,1,1,Marco Peereboom,2018-12-07 16:02:12,https://github.com/decred/politeia/commit/ca4cdf83f0ee5248f24940f77b8c56246c5ce508
-119,1,1,Kevin,2018-12-07 11:57:06,https://github.com/decred/politeia/commit/df92852ee6a6763347a10403a85cf3abe50dc1f2
-120,1,1,Kevin,2018-12-03 19:21:35,https://github.com/decred/politeia/commit/73e375d3d3a498d0367089e7caa4dfad4fc6178b
-121,1,1,Fernando Abolafio,2018-12-03 14:49:31,https://github.com/decred/politeia/commit/fe4e341ce046d51fe0eb0349f0e4aa3e2097b0cd
-122,1,1,Thiago de Freitas Figueiredo,2018-12-01 12:18:14,https://github.com/decred/politeia/commit/ae149f59921240a657f80b04776f4ddf646c37ff
-123,1,1,Seth Benton,2018-11-30 22:24:42,https://github.com/decred/politeia/commit/ca9879763259d7c2f79be578a9dbd4054b5a464b
-124,1,1,Victor Guedes,2018-11-30 21:20:24,https://github.com/decred/politeia/commit/d057a8aad8b5d77b60515e264624ce6ca3e3a887
-125,1,1,lukebp,2018-11-30 14:34:55,https://github.com/decred/politeia/commit/12aeb5b6ec6a1a29a8812d7f0eaf1ae53f6b1551
-126,1,1,lukebp,2018-11-30 13:57:33,https://github.com/decred/politeia/commit/6f219dcc4938ab67e27450bfc6fdc1c699c023fb
-127,1,1,lukebp,2018-11-30 13:52:29,https://github.com/decred/politeia/commit/8eaa6745760d835255212a65c19b6b2b8375de0e
-128,1,1,Thiago de Freitas Figueiredo,2018-11-30 13:51:37,https://github.com/decred/politeia/commit/f5b4f10bcb7d7fd6da36232d268a13a93925f81d
-129,1,1,lukebp,2018-11-30 13:48:10,https://github.com/decred/politeia/commit/5895a1394f7301e26b7416c4bf178c7369892981
-130,1,1,Fernando Abolafio,2018-11-29 21:08:29,https://github.com/decred/politeia/commit/b9d34d285f5eb008702c8a9e1ce146c502653ec0
-131,1,1,David Hill,2018-11-29 17:14:20,https://github.com/decred/politeia/commit/449d9c09f432f10902b0833755666bacf83d57e3
-132,1,1,Sean Durkin,2018-11-27 14:17:45,https://github.com/decred/politeia/commit/bf36bad02071753b78577d572678a43d84461f82
-133,1,1,lukebp,2018-11-19 18:18:48,https://github.com/decred/politeia/commit/3a7c386f4c726137bc67bae3f00386bde7d92287
-134,1,1,lukebp,2018-11-16 20:30:28,https://github.com/decred/politeia/commit/cc17ab6f49795e3b3035b439df74f2db6fc49079
-135,1,1,Sean Durkin,2018-11-15 16:22:31,https://github.com/decred/politeia/commit/a5ff2a88faacfa436ebcd9feaae4415db56ea54e
-136,1,1,David Hill,2018-11-14 18:08:58,https://github.com/decred/politeia/commit/12f7378558c1752ccdc3cf7f1a70109a1f18b120
-137,1,1,Tiago Alves Dulce,2018-11-14 14:42:31,https://github.com/decred/politeia/commit/c36457e458b3419b755f6d2fa5fd3c9d1e1f595a
-138,1,1,Fernando Abolafio,2018-11-14 14:22:46,https://github.com/decred/politeia/commit/4a8c7e5f207ee8b8f7f7efd5f8f260bb3a894458
-139,1,1,Fernando Abolafio,2018-11-13 14:47:20,https://github.com/decred/politeia/commit/6d7eb9834b060be02ac5ca5f250dae2c52e7e4ac
-140,1,1,lukebp,2018-11-09 16:16:52,https://github.com/decred/politeia/commit/595137dd542ab1af0df39053243465d862266e74
-141,1,1,degeri,2018-11-09 15:11:38,https://github.com/decred/politeia/commit/f66e5be1b767e572458059acde6eff0b302bcd79
-142,1,1,lukebp,2018-11-09 15:05:07,https://github.com/decred/politeia/commit/3fcf1fb0884d8ff259c810408c59c10d66f83329
-143,1,1,Fernando Abolafio,2018-11-06 14:08:57,https://github.com/decred/politeia/commit/61f5f8c4e569e3730ae3dfad4c427b8d2d40d6ee
-144,1,1,lukebp,2018-11-04 00:18:40,https://github.com/decred/politeia/commit/5ba517958a145e693c17dc807ed775dd2251777c
-145,1,1,David Hill,2018-11-01 22:41:45,https://github.com/decred/politeia/commit/f91cb149b04de6e7a942dd3fab2848ce5ad2bb8c
-146,1,1,lukebp,2018-11-01 19:59:57,https://github.com/decred/politeia/commit/7697cd02e05b76cf7782e2d952fe0e833a384a9d
-147,1,1,David Hill,2018-11-01 14:17:58,https://github.com/decred/politeia/commit/7a469b90c282ffaaa34af0804b3a92c67297a5c6
-148,1,1,Marco Peereboom,2018-10-31 20:57:32,https://github.com/decred/politeia/commit/9a765f875895bbc78e0eec0dd4d38d80cb7fcdee
-149,1,1,Fernando Abolafio,2018-10-31 13:30:20,https://github.com/decred/politeia/commit/b9e5d8a9a4a97e67cf2b1514839fd4b1708919c5
-150,1,1,Marco Peereboom,2018-10-25 20:23:10,https://github.com/decred/politeia/commit/652443ae5d247f7f4e33c9cce8a1f01d87cf3e14
-151,1,1,Sean Durkin,2018-10-23 19:38:45,https://github.com/decred/politeia/commit/7c2d6e0f82e8770ab7748d174f8cafc9fa5277ff
-152,1,1,Mawueli Kofi Adzoe,2018-10-23 18:50:26,https://github.com/decred/politeia/commit/435fe5c078f5986b73a3c17452b4013d3481edb4
-153,1,1,lukebp,2018-10-23 18:48:27,https://github.com/decred/politeia/commit/afeecd0181a0c46305c4c5917d90060a18d47b24
-154,1,1,VcTT,2018-10-23 13:24:02,https://github.com/decred/politeia/commit/42be2de0c8ba14dbedfdcf5ab70fcb153bfb7f75
-155,1,1,Fernando Abolafio,2018-10-22 18:05:16,https://github.com/decred/politeia/commit/2f360bee12b33d20aa2d75deef7d70254bd4d27c
-156,1,1,lukebp,2018-10-22 15:36:43,https://github.com/decred/politeia/commit/de5a779a76875471fcaf3d0d4661c7e057c2d5dd
-157,1,1,Sean Durkin,2018-10-21 21:16:21,https://github.com/decred/politeia/commit/9b90ffa5a6b54d8a72ea5599c67c57b7e7947e36
-158,1,1,lukebp,2018-10-19 20:06:49,https://github.com/decred/politeia/commit/8ce48ad4a1e96c045335eaef3105eb9ce1cb0711
-159,1,1,Sean Durkin,2018-10-18 15:29:16,https://github.com/decred/politeia/commit/f63e36f4f58ec9d08f088d2ad6303aaa74d389eb
-160,1,1,Sean Durkin,2018-10-18 15:02:40,https://github.com/decred/politeia/commit/7dae64e194ce416db087e0107e04ae0a335a89f0
-161,1,1,Marco Peereboom,2018-10-17 20:39:31,https://github.com/decred/politeia/commit/98481e9ffa0f17b5ca3ea392040c4fbe26eaaf38
-162,1,1,Sean Durkin,2018-10-17 19:25:11,https://github.com/decred/politeia/commit/b4f7d5d08bb33e0a86fd73fb37c8e61eb551af2e
-163,1,1,Sean Durkin,2018-10-17 15:59:59,https://github.com/decred/politeia/commit/23ff40ca9afc60b7942fa7612dc3cb390d8268f0
-164,1,1,Fernando Abolafio,2018-10-17 15:59:21,https://github.com/decred/politeia/commit/5229365a201e7eb3d76887eacad44bf86774a559
-165,1,1,Sean Durkin,2018-10-17 15:44:09,https://github.com/decred/politeia/commit/10598e3c2722b24ac219be4d69a216b27a301ce2
-166,1,1,Marco Peereboom,2018-10-17 15:43:10,https://github.com/decred/politeia/commit/908b2cc7a753ba670ed326ae51dd7d20c0875d18
-167,1,1,Sean Durkin,2018-10-17 14:22:35,https://github.com/decred/politeia/commit/0158643b6e704444d72cae14c2c8b659aac96fbd
-168,1,1,lukebp,2018-10-16 11:56:52,https://github.com/decred/politeia/commit/9f9149dbf2aa39839010cd6249827e7a68b8675c
-169,1,1,Marco Peereboom,2018-10-15 21:21:19,https://github.com/decred/politeia/commit/4cd2f3bb550914e955afbc44585a13c5aa417975
-170,1,1,Fernando Abolafio,2018-10-15 20:27:33,https://github.com/decred/politeia/commit/d9bc6c41ac3a856e7e342a4326dd6f271c572d2a
-171,1,1,Marco Peereboom,2018-10-15 20:20:04,https://github.com/decred/politeia/commit/567bd319d2f4287a4f093c0daeb9bf4dd1095d10
-172,1,1,Tiago Alves Dulce,2018-10-15 18:16:12,https://github.com/decred/politeia/commit/77bdc6c0c23d895a06df4767696cbfd8a4ffd158
-173,1,1,Marco Peereboom,2018-10-15 18:15:08,https://github.com/decred/politeia/commit/72d147f52dea2723d3f7ee0082144a8183cf722c
-174,1,1,Fernando Abolafio,2018-10-15 17:27:33,https://github.com/decred/politeia/commit/369c42e159f1125e0ce1107435cb1a989998d64b
-175,1,1,lukebp,2018-10-15 15:40:09,https://github.com/decred/politeia/commit/498ef3b79e3b3546d725ed6887214bd6e971e61a
-176,1,1,Marco Peereboom,2018-10-12 17:54:30,https://github.com/decred/politeia/commit/5a88ae0a6619503a91314ba40831bb3a11e19dc4
-177,1,1,Marco Peereboom,2018-10-09 14:53:46,https://github.com/decred/politeia/commit/da69903f25d4474baed325c64ff668f60e70a7ad
-178,1,1,lukebp,2018-10-09 14:41:42,https://github.com/decred/politeia/commit/7bbb0871ed2ac5030615e24629108f229617cbec
-179,1,1,Marco Peereboom,2018-10-05 20:17:26,https://github.com/decred/politeia/commit/8fdc8395b1b3c851c8b351778f14fbdbd83f78b8
-180,1,1,David Hill,2018-10-05 14:45:20,https://github.com/decred/politeia/commit/0a3a75ba7481a6d62950003caae4a34ecf73d367
-181,1,1,Fernando Abolafio,2018-10-05 13:31:49,https://github.com/decred/politeia/commit/1a8c9421cac2e1257ebec16d52001aa0a483a148
-182,1,1,lukebp,2018-10-04 17:51:21,https://github.com/decred/politeia/commit/500d4f8cb73bbb33fc60f565c444fff14f5b4501
-183,1,1,lukebp,2018-10-03 17:11:10,https://github.com/decred/politeia/commit/fe3510d73cc607af06d47e155e59fae041824991
-184,1,1,Tiago Alves Dulce,2018-10-03 15:32:28,https://github.com/decred/politeia/commit/ec0bed452cef859d4596c83fb2e180c7b6b7900a
-185,1,1,Fernando Abolafio,2018-10-02 15:58:55,https://github.com/decred/politeia/commit/08f854c6877fdc98bc91560bd4bbb56661cfa686
-186,1,1,Marco Peereboom,2018-10-01 15:50:15,https://github.com/decred/politeia/commit/c3217fd27d1b966defc79201c0d90764cbba64ff
-187,1,1,Marco Peereboom,2018-09-28 13:26:23,https://github.com/decred/politeia/commit/2b184624aa7880cf729488d3b0b727dac9c3424c
-188,1,1,Thiago de Freitas Figueiredo,2018-09-27 14:15:43,https://github.com/decred/politeia/commit/55e6706959765422d01818983777047a5ec18893
-189,1,1,Marco Peereboom,2018-09-26 22:34:08,https://github.com/decred/politeia/commit/f4c075780bed786a1faebe29b1692512dbe44b36
-190,1,1,lukebp,2018-09-26 20:48:53,https://github.com/decred/politeia/commit/edd35ad8aca0cd6e833355ed9ca3f910ad80f2c0
-191,1,1,lukebp,2018-09-26 20:43:06,https://github.com/decred/politeia/commit/be702439e795a8e18cd82dd2c701a495c80fdba0
-192,1,1,lukebp,2018-09-26 20:42:26,https://github.com/decred/politeia/commit/ccf106088ce0372efd9ea097153528ee92788db5
-193,1,1,Fernando Abolafio,2018-09-25 17:15:21,https://github.com/decred/politeia/commit/2ad0e1d5da0d5d37d4423ab011efee043df5772b
-194,1,1,lukebp,2018-09-25 13:59:13,https://github.com/decred/politeia/commit/6a514bb271c324ab25f9bbe0b204727c6de7dc1f
-195,1,1,lukebp,2018-09-25 13:55:56,https://github.com/decred/politeia/commit/8df6ae6c9c079df6499ac25ccb1be2c9394851b0
-196,1,1,lukebp,2018-09-19 20:56:06,https://github.com/decred/politeia/commit/2729f77d1727ab21bdb043866c51f330e5e5833e
-197,1,1,lukebp,2018-09-18 21:44:24,https://github.com/decred/politeia/commit/714024a05ed9cc4d43b7da92c8744931f91d33b7
-198,1,1,lukebp,2018-09-18 16:01:44,https://github.com/decred/politeia/commit/f0622b64920f1be163964be4e46e0da1547016bf
-199,1,1,lukebp,2018-09-17 21:12:02,https://github.com/decred/politeia/commit/b395e01336dfd86d430b30fd4a50c6033b65e6a3
-200,1,1,lukebp,2018-09-11 20:03:14,https://github.com/decred/politeia/commit/52f2c7d6e11b90d710ac4fa4a4079ca933de46bb
-201,1,1,Fernando Abolafio,2018-09-11 15:26:15,https://github.com/decred/politeia/commit/29b134cfd2e1f3d025144d334835623a129df47a
-202,1,1,lukebp,2018-09-10 18:33:21,https://github.com/decred/politeia/commit/d6313578e386990b5eb3716531e72a999dd938b8
-203,1,1,Marco Peereboom,2018-09-07 19:01:02,https://github.com/decred/politeia/commit/5f2637c6596e973e17d3c4e87a2e69315bbc5ce1
-204,1,1,Tiago Alves Dulce,2018-09-07 17:44:08,https://github.com/decred/politeia/commit/29db563ff62cadcdf123a75d222303b874979e32
-205,1,1,VcTT,2018-09-06 15:33:43,https://github.com/decred/politeia/commit/9e832d2deac25b94d5a9d94eddc9ad5e2cbc2d3f
-206,1,1,Sean Durkin,2018-09-06 14:43:52,https://github.com/decred/politeia/commit/7ca6c4ca572a538c6b9a7cd4fe583f85b8d688a4
-207,1,1,lukebp,2018-09-06 14:28:03,https://github.com/decred/politeia/commit/3f777277f5e993e8a1c2b0bddcff876d855cac23
-208,1,1,Fernando Abolafio,2018-09-05 20:18:28,https://github.com/decred/politeia/commit/a6670587bec450f0d80ea713df1d05d1aa9ceb62
-209,1,1,lukebp,2018-09-05 17:33:47,https://github.com/decred/politeia/commit/3554204bd1d622bdafd044072a81fc26723e4f56
-210,1,1,lukebp,2018-09-05 16:18:49,https://github.com/decred/politeia/commit/9c5b89a5574ea4f35a31e91269cf0cf02522eb3c
-211,1,1,lukebp,2018-09-05 12:50:24,https://github.com/decred/politeia/commit/c250d735f8b4302421e8d30277aa0b542174ee5b
-212,1,1,Tiago Alves Dulce,2018-09-04 21:14:55,https://github.com/decred/politeia/commit/0d89503a62fc4ac0e4db34cfd57000d4a1e94c4a
-213,1,1,Fernando Abolafio,2018-09-04 21:00:55,https://github.com/decred/politeia/commit/7d5671813a922251bd9f2cc7dff49e8453234323
-214,1,1,Fernando Abolafio,2018-09-04 13:55:40,https://github.com/decred/politeia/commit/34b3dc53b238d7a2df98e7857551af82a926ccf7
-215,1,1,Fernando Abolafio,2018-08-31 21:34:02,https://github.com/decred/politeia/commit/1074ff144d535f6ce2d9dc11737de6e8bf2f254a
-216,1,1,David Hill,2018-08-31 14:32:24,https://github.com/decred/politeia/commit/b87501f12ca7007a56283e98eccdc87227853ab7
-217,1,1,Fernando Abolafio,2018-08-31 14:11:04,https://github.com/decred/politeia/commit/15fb43ea1b1e064619e1e8e290eba695e18c9a51
-218,1,1,David Hill,2018-08-30 16:54:00,https://github.com/decred/politeia/commit/95c949968a5b9a9657fbfa8e23d0942f7304a571
-219,1,1,lukebp,2018-08-30 16:52:32,https://github.com/decred/politeia/commit/349ff21bf75600a604a244b84c2d435cc9241eb0
-220,1,1,Fernando Abolafio,2018-08-30 14:47:44,https://github.com/decred/politeia/commit/774f62a4e3758370641971bbee79667ef0462b4e
-221,1,1,Marco Peereboom,2018-08-30 14:39:04,https://github.com/decred/politeia/commit/ada6ebdf607b06d6a63ec4df144527f6c88f1d01
-222,1,1,David Hill,2018-08-29 20:57:00,https://github.com/decred/politeia/commit/22fad06714872ae985ae439974a8d9b7ac9385f1
-223,1,1,Marco Peereboom,2018-08-29 20:04:22,https://github.com/decred/politeia/commit/40d8f17928dae69c27ea6b5d4f855cb3cce79328
-224,1,1,Fernando Abolafio,2018-08-20 15:26:30,https://github.com/decred/politeia/commit/4f006056ed85c7d83011b0e6afbdc86cc4109f44
-225,1,1,Fernando Abolafio,2018-08-13 17:46:55,https://github.com/decred/politeia/commit/9bc5ceb6c3bbdeb39ce3177aed0a9ddd196326a2
-226,1,1,lukebp,2018-08-11 12:45:45,https://github.com/decred/politeia/commit/6faaf11599625f5522a8b3179f975e458e758531
-227,1,1,Sean Durkin,2018-08-08 23:59:14,https://github.com/decred/politeia/commit/a0bade8bd0139394f8ec016efe7f9e9bbcefb606
-228,1,1,David Hill,2018-08-08 18:46:38,https://github.com/decred/politeia/commit/4189ae24dcb711aea501ea698d890a60aa07d3a1
-229,1,1,Sean Durkin,2018-08-02 15:09:13,https://github.com/decred/politeia/commit/09f4d067e6712d7a167594771495017b6a347926
-230,1,1,Sean Durkin,2018-08-02 14:20:52,https://github.com/decred/politeia/commit/ea349fa9e76ff58221ef71b98d6514137f43b811
-231,1,1,Sean Durkin,2018-08-02 14:14:10,https://github.com/decred/politeia/commit/1db07b22cab9274f1c66b946dc3e7c202553bfcf
-232,1,1,Sean Durkin,2018-08-01 10:16:54,https://github.com/decred/politeia/commit/cbabfafebadeb40a9f7046d8e8e5901ed8da8662
-233,1,1,lukebp,2018-08-01 04:51:54,https://github.com/decred/politeia/commit/afc132b4ef97fa7074c1e2ade6ccb171117b457a
-234,1,1,lukebp,2018-07-30 15:18:32,https://github.com/decred/politeia/commit/0bc359bb67b91d30dc95561850da50e6d8f2d676
-235,1,1,lukebp,2018-07-27 10:51:22,https://github.com/decred/politeia/commit/fd0cfea103849bc7c782a7dd647aba439f90cce3
-236,1,1,Sean Durkin,2018-07-26 14:20:23,https://github.com/decred/politeia/commit/0762b1cf1b22076a428b972fad996b9efe13acec
-237,1,1,lukebp,2018-07-25 15:27:47,https://github.com/decred/politeia/commit/a146e3272e32727f9c54c38c8fdd5aab48ee9f8f
-238,1,1,VcTT,2018-07-25 14:54:04,https://github.com/decred/politeia/commit/3c9e90bd7ca00a6c0ea37c318d4c8b469e95c1e8
-239,1,1,Hector Sanjuan,2018-07-25 13:18:40,https://github.com/decred/politeia/commit/091909b9485464f823173ff808f822fba38de87d
-240,1,1,VcTT,2018-07-25 13:13:53,https://github.com/decred/politeia/commit/914c2fada4867ce49fd3bd8a2ab11170fbfdb381
-241,1,1,lukebp,2018-07-23 22:19:07,https://github.com/decred/politeia/commit/83e52c061c68a09631f46b8998532c8b6ba11339
-242,1,1,Fernando Abolafio,2018-07-20 20:40:47,https://github.com/decred/politeia/commit/63410369153a9705acb33a1385cb3925958db04a
-243,1,1,David Hill,2018-07-18 23:31:30,https://github.com/decred/politeia/commit/c0565a7aadd5f3c2a1f7b0c60bed260d5103821a
-244,1,1,Sean Durkin,2018-07-18 13:39:10,https://github.com/decred/politeia/commit/f7c55602cd2a4008fcfdc0955de06ed0416f708a
-245,1,1,Marco Peereboom,2018-07-17 16:55:52,https://github.com/decred/politeia/commit/9143989b65d752e1cafcfebce3c836777604ed3e
-246,1,1,Fernando Abolafio,2018-07-17 14:21:07,https://github.com/decred/politeia/commit/568b9904d9bf1f17d8b6e0b9d6d4dc06103263fb
-247,1,1,Sean Durkin,2018-07-13 12:52:05,https://github.com/decred/politeia/commit/a2186930bc72908293fd36215af57bcffcdfdd9c
-248,1,1,Fernando Abolafio,2018-07-13 12:16:12,https://github.com/decred/politeia/commit/1655ad3fa25bfa126d21a29d44f0831838a9d5c4
-249,1,1,Sean Durkin,2018-07-12 00:01:36,https://github.com/decred/politeia/commit/da44c1613bffb0f52688e79eacc900f5b4b954a3
-250,1,1,Sean Durkin,2018-07-06 13:27:07,https://github.com/decred/politeia/commit/dd24a0a387965b3175490ec7d59c2a89cb2e885d
-251,1,1,Tiago Alves Dulce,2018-07-05 13:17:03,https://github.com/decred/politeia/commit/5c82398f935046f7ef8eee6245198daeb3349c2e
-252,1,1,Sean Durkin,2018-07-03 16:01:55,https://github.com/decred/politeia/commit/faff72eb2e4a2cdd631e800040e9af37918cf2f1
-253,1,1,Marco Peereboom,2018-07-03 15:12:38,https://github.com/decred/politeia/commit/d536b990e39ea7fb9623ef74eb9450e2dd7cb6bc
-254,1,1,Marco Peereboom,2018-07-03 11:14:21,https://github.com/decred/politeia/commit/cf642bed5da5dc3aa25fdae3c61c30c185dbdacf
-255,1,1,Tiago Alves Dulce,2018-07-03 08:48:45,https://github.com/decred/politeia/commit/af31e70aa60a20933c8525ee326f097a045ac8b8
-256,1,1,lte13,2018-07-02 11:24:40,https://github.com/decred/politeia/commit/dbde73bb14a7fdc6832f4b1ee38fc72bc7933152
-257,1,1,Ramon Recuero,2018-07-02 11:05:45,https://github.com/decred/politeia/commit/ec3f1839d71a53e333b31e9dabc41e8581955b6b
-258,1,1,Sean Durkin,2018-06-29 15:47:57,https://github.com/decred/politeia/commit/ab2eaee225e22d1dc71001555e2b44d0ae3579e6
-259,1,1,Sean Durkin,2018-06-29 15:47:15,https://github.com/decred/politeia/commit/647e7dbefab3d9a2b0d757d5c7b08f85c83e838b
-260,1,1,Fernando Abolafio,2018-06-29 15:34:48,https://github.com/decred/politeia/commit/d82247aa31177ce807f9c2495e84451e034066d2
-261,1,1,Tiago Alves Dulce,2018-06-26 22:53:47,https://github.com/decred/politeia/commit/d150d914de0d0e4f5cc44b9f73c21fcb09427dae
-262,1,1,Fernando Abolafio,2018-06-25 16:36:38,https://github.com/decred/politeia/commit/f5ee11c3ec0bf15e53cadfb70156a063106d39ff
-263,1,1,RichardRed0x,2018-06-25 16:29:23,https://github.com/decred/politeia/commit/d3447751372bdd881b64d04c49a09b0b1522ed2c
-264,1,1,Sean Durkin,2018-06-25 16:13:17,https://github.com/decred/politeia/commit/d339b73812ca8be442618430dcf8857a3437ba05
-265,1,1,Tiago Alves Dulce,2018-06-25 14:47:08,https://github.com/decred/politeia/commit/44c3bbe4908df98ae6c11c02f388b1dad3c0872e
-266,1,1,Sean Durkin,2018-06-22 14:04:47,https://github.com/decred/politeia/commit/321b7b0a5c64fd6c5d5eba1edb2ca4d3e47ce6e8
-267,1,1,Sean Durkin,2018-06-22 14:04:17,https://github.com/decred/politeia/commit/701031e4dafec087badd6e01dd9635ea6b028f3a
-268,1,1,Marco Peereboom,2018-06-22 12:02:09,https://github.com/decred/politeia/commit/8cb8ad3270182ee5b2e21dab13ee5d0fd55f5e1b
-269,1,1,lukebp,2018-06-22 10:36:52,https://github.com/decred/politeia/commit/2410f36f9739c50f926591a2a216c8d8d115678f
-270,1,1,Fernando Abolafio,2018-06-20 21:28:29,https://github.com/decred/politeia/commit/53dbbdec3dbaef0ba2d1f2929b621a6162d2d64e
-271,1,1,Fernando Abolafio,2018-06-20 17:39:39,https://github.com/decred/politeia/commit/3d7f1b2ba767b5ef8793ba3c129d34dabbdf0638
-272,1,1,Marco Peereboom,2018-06-19 16:51:07,https://github.com/decred/politeia/commit/25df51a6b1ff449eba522d0f85f4395671ba1317
-273,1,1,Marco Peereboom,2018-06-19 12:17:56,https://github.com/decred/politeia/commit/7f1171348954227150f66215b7de52bfdc9132ce
-274,1,1,lukebp,2018-06-15 09:03:04,https://github.com/decred/politeia/commit/fa830b03f6984b6c45a0a470ab0680b82f56ea2c
-275,1,1,Marco Peereboom,2018-06-13 15:54:26,https://github.com/decred/politeia/commit/5fd08a0933ebc3e279d59666a2f8f717c647b1b9
-276,1,1,Decebal Dobrica,2018-06-13 14:35:20,https://github.com/decred/politeia/commit/a449b145767d1478b55c593b62048a9030a99820
-277,1,1,Sean Durkin,2018-06-11 21:14:02,https://github.com/decred/politeia/commit/dab0a679c407a1818b7688d132ccf16a9a0f79ab
-278,1,1,Marco Peereboom,2018-06-11 21:06:43,https://github.com/decred/politeia/commit/61e8e3376894ebba9486d3b23412f5e3edb5a216
-279,1,1,Fernando Abolafio,2018-06-11 20:38:11,https://github.com/decred/politeia/commit/9333ecd896d4c75bf67b994a3b527a5875fae6d9
-280,1,1,David Hill,2018-06-07 21:59:53,https://github.com/decred/politeia/commit/fe3bdead1b7b665770f016c3d29b1efb33f2711f
-281,1,1,Marco Peereboom,2018-06-07 17:19:34,https://github.com/decred/politeia/commit/ab2b0786d2f06104f3caa6b8f15702afa7e08089
-282,1,1,Sean Durkin,2018-06-05 19:57:06,https://github.com/decred/politeia/commit/8b12d78fbc24f5f0e1b8012f8efd597e0f0f2dc4
-283,1,1,lukebp,2018-06-04 08:25:50,https://github.com/decred/politeia/commit/17096922feb9b4a99cc35e64d75fcbadc0ffc726
-284,1,1,lukebp,2018-05-31 15:57:16,https://github.com/decred/politeia/commit/f2625bbd7c72314d5ecff01fc7198da40d4f2df0
-285,1,1,Sean Durkin,2018-05-30 14:10:47,https://github.com/decred/politeia/commit/0b010d92827c58d81aee662e1c18fc3110d1c734
-286,1,1,Luke Powell,2018-05-25 12:29:27,https://github.com/decred/politeia/commit/e4c6bec23b1e2a3a38096df798224899f2636d4f
-287,1,1,Sean Durkin,2018-05-23 15:54:35,https://github.com/decred/politeia/commit/dd676a6a8bd34f2dd008e81b62388c9817b08049
-288,1,1,Sean Durkin,2018-05-21 17:56:19,https://github.com/decred/politeia/commit/8ea40eb94c8159f151016034de6ae2243c865f76
-289,1,1,Fernando Abolafio,2018-05-18 16:37:00,https://github.com/decred/politeia/commit/bb70975e994a0be29805be0d7fea66b4564c2859
-290,1,1,Sean Durkin,2018-05-15 13:26:53,https://github.com/decred/politeia/commit/9ee62142fd75582e8c2a13a673e046858ce2efe4
-291,1,1,Luke Powell,2018-05-11 17:56:41,https://github.com/decred/politeia/commit/fb51368254d7807a5d3e0c5c71e9b9e751977f8c
-292,1,1,Sean Durkin,2018-05-11 13:11:32,https://github.com/decred/politeia/commit/6e64cf2836a85e42c54b7cbe65f8146a082b4fba
-293,1,1,Fernando Abolafio,2018-05-10 15:04:18,https://github.com/decred/politeia/commit/b900fc8a301b36c10f7ae583cf4127d68953c9b6
-294,1,1,Fernando Abolafio,2018-05-09 20:28:53,https://github.com/decred/politeia/commit/5be9c863a34827beabffc5ed01c46b8a10834dde
-295,1,1,Fernando Abolafio,2018-05-09 18:08:51,https://github.com/decred/politeia/commit/00735c2c598e8b2197064d5c8eb32ae0e1de10c1
-296,1,1,Everton Melo,2018-05-08 21:26:45,https://github.com/decred/politeia/commit/0ebd4769ea438562531cc5f517c3914d777fa95f
-297,1,1,David Hill,2018-05-03 15:20:39,https://github.com/decred/politeia/commit/a91b44000b79a7230829a62997405ab091d073b6
-298,1,1,VcTT,2018-05-03 15:12:05,https://github.com/decred/politeia/commit/cd7ade4d74d44837e971b2894a35e639e5f13ebd
-299,1,1,VcTT,2018-04-30 14:55:28,https://github.com/decred/politeia/commit/9e227dbb7e1e4c4f2585c1a7f44ef16c1359fb3f
-300,1,1,Marco Peereboom,2018-04-20 18:51:14,https://github.com/decred/politeia/commit/228a8413b2373aedb7e96c74397800447f141e8d
-301,1,1,Marco Peereboom,2018-04-17 18:25:33,https://github.com/decred/politeia/commit/78d939066c4f2f1ff050db0cfc357e7c35240593
-302,1,1,Marco Peereboom,2018-04-17 17:46:55,https://github.com/decred/politeia/commit/eaa75c5549035047c876849e86ac9609a3d30b34
-303,1,1,Marco Peereboom,2018-04-17 16:16:22,https://github.com/decred/politeia/commit/882d531c16b7ef56579646823b185d836dfedc8a
-304,1,1,Marco Peereboom,2018-04-16 21:06:43,https://github.com/decred/politeia/commit/bb59d199f3a395b4a9e2d2ce4e482c00aacf8666
-305,1,1,Marco Peereboom,2018-04-16 19:56:45,https://github.com/decred/politeia/commit/f509f9e74aa6030d1a35053464f381f0f93319c8
-306,1,1,Marco Peereboom,2018-04-16 17:52:39,https://github.com/decred/politeia/commit/a818ad4eb134193cbc32c78e0b8eb47688f23be5
-307,1,1,Marco Peereboom,2018-04-13 15:43:30,https://github.com/decred/politeia/commit/6cb4150de70c6e49adf12b413c871acc924e3417
-308,1,1,Victor Oliveira,2018-04-12 21:56:35,https://github.com/decred/politeia/commit/3308450f482b7937840dee25ad357ec0ee929b25
-309,1,1,Victor Oliveira,2018-04-12 20:22:58,https://github.com/decred/politeia/commit/de601294199c4b3d034dba68a1aa7843fc0b5a81
-310,1,1,David Hill,2018-04-12 20:22:17,https://github.com/decred/politeia/commit/5433e70e6652a568c6013dcbabfbf7617d42b0c2
-311,1,1,David Hill,2018-04-10 20:53:51,https://github.com/decred/politeia/commit/6d444a5f107758e1a42e8400d538068066f5b0e8
-312,1,1,Marco Peereboom,2018-04-10 16:01:39,https://github.com/decred/politeia/commit/fd86d98c7baa6d59b18a641243cc31a96c9c9e79
-313,1,1,David Hill,2018-04-03 16:37:34,https://github.com/decred/politeia/commit/f666a193a2f087a69636acb44b026556197cbea5
-314,1,1,David Hill,2018-04-03 16:37:14,https://github.com/decred/politeia/commit/8a005a38b5a4f83e08f3e155590c7b382df06e00
-315,1,1,Sean Durkin,2018-03-30 16:03:07,https://github.com/decred/politeia/commit/3482dab52233ec9c51d1ca97636a0435935ae2a2
-316,1,1,sudoscript,2018-03-20 18:55:53,https://github.com/decred/politeia/commit/e6eedfdf0f63953f872e8af649e895dcc5b8caa3
-317,1,1,Sean Durkin,2018-03-13 14:33:34,https://github.com/decred/politeia/commit/fe537f99c37641b0a26a3d9a4c91e90abbe62c6d
-318,1,1,David Hill,2018-02-16 18:31:03,https://github.com/decred/politeia/commit/b78339ca21cc4423ff08fd441730a1fb12083b9c
-319,1,1,AlanL1,2018-02-13 21:45:03,https://github.com/decred/politeia/commit/22f67dc53ce4807fae021ad822004c21b3010748
-320,1,1,AlanL1,2018-02-08 15:00:15,https://github.com/decred/politeia/commit/ba21c380b30411de0a83ee11c579377a91068323
-321,1,1,Victor Oliveira,2018-02-06 15:35:22,https://github.com/decred/politeia/commit/54f8325773da51865c4c84315c82cdfed0f31387
-322,1,1,Sean Durkin,2018-02-06 15:33:40,https://github.com/decred/politeia/commit/2b6061faf1915c7adc4629206e20e9fd089b97c1
-323,1,1,Sean Durkin,2018-01-23 16:23:50,https://github.com/decred/politeia/commit/30cc2c072c714c9de2ba73392591175087aae3b2
-324,1,1,Fernando Abolafio,2018-01-23 14:33:50,https://github.com/decred/politeia/commit/79d261371994174e87fe890c53d157b9e5002540
-325,1,1,Sean Durkin,2018-01-23 14:31:51,https://github.com/decred/politeia/commit/05cb9c3a170f9d787ce9c45b288794aa71ba151d
-326,1,1,Fernando Abolafio,2018-01-22 15:39:22,https://github.com/decred/politeia/commit/fe356e79242716b66610ed20bcfa2fff7f2afa92
-327,1,1,Sean Durkin,2018-01-22 15:34:57,https://github.com/decred/politeia/commit/84c88f9cced904ce81281d34e8e1bb178c5662f6
-328,1,1,Sean Durkin,2018-01-16 17:20:55,https://github.com/decred/politeia/commit/b38e4d1621af574d46fc25440285104e191f9f81
-329,1,1,Ricardo Geraldes,2018-01-15 22:30:35,https://github.com/decred/politeia/commit/b7b6b3f5eadddc1377eb90cf49427025ff431b75
-330,1,1,Sean Durkin,2018-01-15 17:23:20,https://github.com/decred/politeia/commit/3013d28f27793231cbec2f3502cb3c7b79678307
-331,1,1,Sean Durkin,2018-01-15 17:22:51,https://github.com/decred/politeia/commit/a7fcd88ae74490952f226abd315e477c990f3b10
-332,1,1,Sean Durkin,2018-01-15 17:21:57,https://github.com/decred/politeia/commit/66118ebd8bb4699897e99473ca1c76cd255b0b4b
-333,1,1,Sean Durkin,2018-01-08 15:37:52,https://github.com/decred/politeia/commit/d4ff16ef37371603e7505369a3c2bc4158893a17
-334,1,1,Sean Durkin,2018-01-08 15:29:39,https://github.com/decred/politeia/commit/8404a6f8dd8a6c6a8f6ee2b7b86e04ffd8cb9e05
-335,1,1,jolan,2017-12-21 20:54:52,https://github.com/decred/politeia/commit/d001f3d55e0ab4410f52d7ff82b6ed6d8951a887
-336,1,1,Marco Peereboom,2017-12-20 14:17:14,https://github.com/decred/politeia/commit/1e3b34b822a433429db60e2553bf29b504836277
-337,1,1,Marco Peereboom,2017-12-15 20:50:59,https://github.com/decred/politeia/commit/0cf238589ba0426c4b20b39e9d7287f795255552
-338,1,1,Marco Peereboom,2017-12-15 19:33:50,https://github.com/decred/politeia/commit/2f9ba653c5187cc7e5dfd2e0ae731cdff84ac70b
-339,1,1,jolan,2017-12-15 18:12:30,https://github.com/decred/politeia/commit/68e79c530907b6b09f8cbe9e4330df55cdef2335
-340,1,1,jolan,2017-12-13 16:18:25,https://github.com/decred/politeia/commit/93db6cdfd9653c3207afb1b0c1a6a776662919bd
-341,1,1,Marco Peereboom,2017-12-07 22:12:10,https://github.com/decred/politeia/commit/737ae59341bdbab3dfe611fe18aaa6ffc3e3371e
-342,1,1,Victor Oliveira,2017-12-07 15:21:57,https://github.com/decred/politeia/commit/c097aaa376ca69bdab79d5125d587a396e0f30e9
-343,1,1,Marco Peereboom,2017-12-04 15:15:27,https://github.com/decred/politeia/commit/841bcaeff75605f8be134daba5937056fc4739fd
-344,1,1,Ricardo Geraldes,2017-12-01 19:40:32,https://github.com/decred/politeia/commit/1fd012b2d8116e1568fd564e4a7d93e5e027441e
-345,1,1,David Hill,2017-12-01 19:21:42,https://github.com/decred/politeia/commit/0c157db305e73ca13f57d6fd1353c409f9a9a1b5
-346,1,1,Marco Peereboom,2017-12-01 19:16:32,https://github.com/decred/politeia/commit/d6c94306bb210a610117ef29508e2a28b2fca24e
-347,1,1,David Hill,2017-12-01 19:06:44,https://github.com/decred/politeia/commit/5ce7c37a72576b1705735c35f1ea45ad13ffdad0
-348,1,1,Marco Peereboom,2017-12-01 18:48:57,https://github.com/decred/politeia/commit/9bcdda3ef64f5be0c062004f3539c44478f8180a
-349,1,1,Marco Peereboom,2017-12-01 18:28:57,https://github.com/decred/politeia/commit/a82cd66548c5015f531fa1f62aa5b5bc36a5e878
-350,1,1,Marco Peereboom,2017-12-01 04:03:45,https://github.com/decred/politeia/commit/19a5f99eb70ad52517ed127d36c3142df088a67f
-351,1,1,Sean Durkin,2017-12-01 03:59:37,https://github.com/decred/politeia/commit/c8986fced41c6505749b657a7a57cc7de35eabde
-352,1,1,Sean Durkin,2017-12-01 03:33:51,https://github.com/decred/politeia/commit/0cf25f4afe6d9f9db133585481dfb2131c625dff
-353,1,1,Sean Durkin,2017-12-01 03:20:42,https://github.com/decred/politeia/commit/60adda783d35e45caf08bcb39bf6499808d490c0
-354,1,1,Marco Peereboom,2017-11-30 18:01:40,https://github.com/decred/politeia/commit/76a52d3f52218c4545599d4b2d36f391f69de8d3
-355,1,1,jolan,2017-11-30 13:26:43,https://github.com/decred/politeia/commit/92b4de7a2126e408736c3eb36e5102a104190891
-356,1,1,Sean Durkin,2017-11-30 13:23:28,https://github.com/decred/politeia/commit/362f717f571053e6b3ec2f5233930a5104345299
-357,1,1,Victor Oliveira,2017-11-20 19:55:35,https://github.com/decred/politeia/commit/452d01339c164939906e2ccba1df9a2f2a897ef2
-358,1,1,Sean Durkin,2017-11-20 15:52:00,https://github.com/decred/politeia/commit/bc5acef640423fad99a898bf612fb677a65857dc
-359,1,1,Sean Durkin,2017-11-20 15:49:59,https://github.com/decred/politeia/commit/a0cb88495d849bfec71848cf6361b1df1ed2c5a8
-360,1,1,Marco Peereboom,2017-11-14 20:35:16,https://github.com/decred/politeia/commit/7899836e2f580f68c2ec6de6e4ba263ba791c461
-361,1,1,Sean Durkin,2017-11-13 19:13:25,https://github.com/decred/politeia/commit/60b0aeae221bb91243edd59cf5a8f7a6a96fc6be
-362,1,1,Sean Durkin,2017-11-13 19:04:48,https://github.com/decred/politeia/commit/449270d5881aef0c6c4ecba68cd6594d64d0c070
-363,1,1,Marco Peereboom,2017-11-13 14:42:53,https://github.com/decred/politeia/commit/93f6acd0dc7dba5233a2271f1f82da741cad2ef6
-364,1,1,vctt94,2017-11-13 13:25:09,https://github.com/decred/politeia/commit/a8c1337b169254b24c9d9c388bb748cef01b266f
-365,1,1,Ricardo Geraldes,2017-11-10 18:09:56,https://github.com/decred/politeia/commit/3a318af082457b19909a91aa853ff68107152b92
-366,1,1,Ricardo Geraldes,2017-11-09 18:35:39,https://github.com/decred/politeia/commit/b56de162f1cebe2b3a050a15cb5a5c6832cc592b
-367,1,1,Marco Peereboom,2017-11-09 15:56:40,https://github.com/decred/politeia/commit/34b0738bc81bc2237594ee31e32e8a22a158677d
-368,1,1,Marco Peereboom,2017-11-09 15:56:10,https://github.com/decred/politeia/commit/b09eca5e738f46837bc2b2283c0e8c8438379e3e
-369,1,1,Sean Durkin,2017-11-09 15:31:45,https://github.com/decred/politeia/commit/0bba4c00cbbb537048af23d50b7e4a6ad5672016
-370,1,1,Sean Durkin,2017-11-08 14:46:35,https://github.com/decred/politeia/commit/4feb70a39c9d55cd334c7094981dc14cd483c167
-371,1,1,Ricardo Geraldes,2017-11-07 02:36:45,https://github.com/decred/politeia/commit/250c6866f78a4c79c10a6e8011dbc00659b2db23
-372,1,1,Marco Peereboom,2017-11-06 22:19:33,https://github.com/decred/politeia/commit/a9910da50026ce41168c74c0d6766de33a47bec5
-373,1,1,Sean Durkin,2017-11-05 19:12:11,https://github.com/decred/politeia/commit/2a6d154fca8209c635d1280c7e5d4a3c555fe9ad
-374,1,1,Sean Durkin,2017-11-02 16:03:34,https://github.com/decred/politeia/commit/f8fe0171df2fe2e0fb4c598795e08807396ec799
-375,1,1,Sean Durkin,2017-10-31 15:40:03,https://github.com/decred/politeia/commit/832f564a32664e98085c4db450a3eedbf8507018
-376,1,1,Sean Durkin,2017-10-31 15:35:22,https://github.com/decred/politeia/commit/7281fbbbdfe8606fd68e3997f87863a92fcc88dc
-377,1,1,Sean Durkin,2017-10-28 18:26:27,https://github.com/decred/politeia/commit/0e1e43ace2e65424d95b3d95175e480beece5768
-378,1,1,Sean Durkin,2017-10-26 15:31:39,https://github.com/decred/politeia/commit/081f7389535d4aa26da5a69c9f58666432775240
-379,1,1,Marco Peereboom,2017-10-25 16:47:20,https://github.com/decred/politeia/commit/a2edaa8efac021043e30a1dd1f39e48b720a9635
-380,1,1,David Hill,2017-10-25 16:29:57,https://github.com/decred/politeia/commit/e3a6c9ae2bf87fa4c89a29bee6850b8975aae1a9
-381,1,1,Marco Peereboom,2017-10-25 13:30:50,https://github.com/decred/politeia/commit/776880fa71240ed984dc15307756a2dac5b08712
-382,1,1,Sean Durkin,2017-10-24 17:23:36,https://github.com/decred/politeia/commit/8521830be2daa5f0b6b453041dffe78b069462f0
-383,1,1,David Hill,2017-10-24 16:41:16,https://github.com/decred/politeia/commit/86ab771c331c5faa2c6a3af29dbaeaa2f9f51139
-384,1,1,Sean Durkin,2017-10-24 13:48:35,https://github.com/decred/politeia/commit/5c4c10f7ea3a082578756283b7c61cb6e9263aba
-385,1,1,Sean Durkin,2017-10-23 17:57:38,https://github.com/decred/politeia/commit/fb59565c63aed075308522d4a4a8eed0c6cc8443
-386,1,1,Sean Durkin,2017-10-23 12:33:23,https://github.com/decred/politeia/commit/ce724341b6f1422c1258e0f6866f15960bea5bb3
-387,1,1,Sean Durkin,2017-10-23 12:21:48,https://github.com/decred/politeia/commit/6199a2f6f1a7e63f793e6fbc1c5c83cf0b5c1119
-388,1,1,Sean Durkin,2017-10-20 15:50:37,https://github.com/decred/politeia/commit/d252d78ac40791a2059f3610f3ac5d25d26065d2
-389,1,1,Marco Peereboom,2017-10-19 20:35:50,https://github.com/decred/politeia/commit/20952e498a7d6ba4d716cb3d0ee1311fc227db57
-390,1,1,Marco Peereboom,2017-10-19 18:56:44,https://github.com/decred/politeia/commit/bbc80aef219a988d5d0ee6d6a0183f8dfe9f6e3f
-391,1,1,Sean Durkin,2017-10-19 16:36:10,https://github.com/decred/politeia/commit/333c72521ea9828dcf72d954e369f693a56f8b59
-392,1,1,Marco Peereboom,2017-10-18 20:35:59,https://github.com/decred/politeia/commit/279af36400578f2e368235878a03beb8182942b7
-393,1,1,David Hill,2017-10-18 16:49:30,https://github.com/decred/politeia/commit/d937594a570187f1fbb8066f688f1b5491a5fba7
-394,1,1,Sean Durkin,2017-10-18 16:26:01,https://github.com/decred/politeia/commit/331b60057a097ac51ad2b058dea1e4300c467490
-395,1,1,Sean Durkin,2017-10-18 16:25:37,https://github.com/decred/politeia/commit/b43110202ebff1015354d4494df83c6996dbb6ee
-396,1,1,Marco Peereboom,2017-10-18 16:22:38,https://github.com/decred/politeia/commit/eb827bfcadfe5bbd8e4d8683ace343e358bf4a9d
-397,1,1,David Hill,2017-10-18 13:32:26,https://github.com/decred/politeia/commit/0ff7a1c923e819ac26e49e5888b0444e2964ad8a
-398,1,1,David Hill,2017-10-17 17:35:35,https://github.com/decred/politeia/commit/32b15523d7af4c966e4ab5853dbd82b1c76818a0
-399,1,1,Sean Durkin,2017-10-17 16:37:49,https://github.com/decred/politeia/commit/62886647d84cc9cec6641a1543b21d7fb2e64227
-400,1,1,Sean Durkin,2017-10-17 15:41:29,https://github.com/decred/politeia/commit/947d0c1a820ee713c8f21d8b9c4ed971d8b9514d
-401,1,1,David Hill,2017-10-17 14:49:05,https://github.com/decred/politeia/commit/72ab785594fa6924d636bd56c05cb3fea8ff8a82
-402,1,1,David Hill,2017-10-16 19:36:45,https://github.com/decred/politeia/commit/cb0680e7ec845ae4ba10c72fb45acd80c3379372
-403,1,1,Sean Durkin,2017-10-16 15:42:11,https://github.com/decred/politeia/commit/76b51b778348dabe8b89f72322d3404ea1e95e97
-404,1,1,Marco Peereboom,2017-10-16 12:47:59,https://github.com/decred/politeia/commit/44750e7bf1b3c87fa45e7058b0e885d2a5dc7869
-405,1,1,Sean Durkin,2017-10-05 19:22:34,https://github.com/decred/politeia/commit/fec5892fb2b3511eb40459d2efa65b54517fa231
-406,1,1,David Hill,2017-10-05 18:15:06,https://github.com/decred/politeia/commit/5246f091ae4662c0d490ad83964466b071c78626
-407,1,1,Marco Peereboom,2017-10-05 15:25:40,https://github.com/decred/politeia/commit/a436b56736874f844d21c975bdd03f326830f563
-408,1,1,Marco Peereboom,2017-10-05 15:25:04,https://github.com/decred/politeia/commit/a2766752dd7a61a71a93033c85725a1905070c85
-409,1,1,Marco Peereboom,2017-10-04 15:59:51,https://github.com/decred/politeia/commit/ea0228d216ca3c99d5aac77a511b6615ab6995be
-410,1,1,Marco Peereboom,2017-10-04 15:47:09,https://github.com/decred/politeia/commit/fd8c2ec474b2f20d9bcd7077936b49b9ad1389a8
-411,1,1,Marco Peereboom,2017-10-04 15:16:53,https://github.com/decred/politeia/commit/e7cb59c89e648c8e6b11e6fc875c8d38f91f7eba
-412,1,1,Marco Peereboom,2017-10-04 14:44:35,https://github.com/decred/politeia/commit/6947d0c69ac3f417417a4aca197fdab67872fdc3
-413,1,1,Sean Durkin,2017-10-03 13:23:43,https://github.com/decred/politeia/commit/9f16c7ac883c18e05e445908ec03c4712043c829
-414,1,1,Sean Durkin,2017-09-29 18:12:14,https://github.com/decred/politeia/commit/b2bd449d25463523248e2e46d18a056311b01463
-415,1,1,Sean Durkin,2017-09-29 18:10:40,https://github.com/decred/politeia/commit/814e46d0400835e54cf26a62902d61b0aaa59733
-416,1,1,David Hill,2017-09-27 20:03:54,https://github.com/decred/politeia/commit/35ab0667c396bd09fe0ae10fa7f2102132be75d4
-417,1,1,Sean Durkin,2017-09-27 14:20:51,https://github.com/decred/politeia/commit/6fa02d5635212b818b2aa8065bc94ef17b557b48
-418,1,1,Sean Durkin,2017-09-26 15:29:51,https://github.com/decred/politeia/commit/d161aecadad09a7e0aa9703868ff6bf364875d6f
-419,1,1,Sean Durkin,2017-09-25 20:50:07,https://github.com/decred/politeia/commit/7d47e688c4664196b82be2b59ff16ef5c9199be4
-420,1,1,Marco Peereboom,2017-09-19 19:03:12,https://github.com/decred/politeia/commit/ae1fe680ca04840ccc347ca18b9674e8284efa41
-421,1,1,Sean Durkin,2017-09-19 13:35:59,https://github.com/decred/politeia/commit/a0de30caec4c3f63af9add9b85758fe49908cb8e
-422,1,1,Marco Peereboom,2017-09-18 17:29:26,https://github.com/decred/politeia/commit/15a70f20a941106fa3633cfb12b4c1d232d6d552
-423,1,1,Marco Peereboom,2017-09-18 17:27:03,https://github.com/decred/politeia/commit/eb07c611fc287f1e7ffa03b090f7afe3012ac5da
-424,1,1,Sean Durkin,2017-09-18 12:50:37,https://github.com/decred/politeia/commit/3adfd983b444f6d2cf33ca3cdbd880636c230f16
-425,1,1,Marco Peereboom,2017-09-15 16:33:52,https://github.com/decred/politeia/commit/675df7983a48f27c6bc0d5e7640ebc62e4f79b67
-426,1,1,Marco Peereboom,2017-09-15 12:58:14,https://github.com/decred/politeia/commit/9f686471088b8ebbfaacf048e81905337e30f348
-427,1,1,Marco Peereboom,2017-09-14 19:29:34,https://github.com/decred/politeia/commit/7f9af9e0b8017aec10f59bfcef402e31cc665802
-428,1,1,Sean Durkin,2017-09-14 19:27:36,https://github.com/decred/politeia/commit/5be8ed66ac3f092ebea245f6eb10fdff6b75f6e4
-429,1,1,Marco Peereboom,2017-09-14 19:06:34,https://github.com/decred/politeia/commit/f339cf4a31f02fe2f8d9a9eec48e3321afc7c3dd
-430,1,1,Marco Peereboom,2017-09-14 01:58:16,https://github.com/decred/politeia/commit/9263e6e47cd8f649d921b1b1b0e4a6251e4c60c8
-431,1,1,Marco Peereboom,2017-09-13 22:01:21,https://github.com/decred/politeia/commit/04608f8b7ea61df52155538da71376081a3bf0c0
-432,1,1,Marco Peereboom,2017-09-13 21:10:19,https://github.com/decred/politeia/commit/bbd1272cd657bb9d5222b24272e3fb5896a26afd
-433,1,1,Sean Durkin,2017-09-13 11:32:16,https://github.com/decred/politeia/commit/f7f58c1cf7a280a1d33bb56a3945d396b974b18a
-434,1,1,Sean Durkin,2017-09-12 13:13:31,https://github.com/decred/politeia/commit/ce36cb5a44deaf2a675be650cd98450704646315
-435,1,1,Marco Peereboom,2017-09-08 14:26:31,https://github.com/decred/politeia/commit/2839c176392a864e1cb4d146939122571973aadc
-436,1,1,Sean Durkin,2017-09-07 12:55:49,https://github.com/decred/politeia/commit/03c1bf5a8d6c58a495f157d1cb194fd1aa4a3ffb
-437,1,1,Marco Peereboom,2017-09-06 22:36:53,https://github.com/decred/politeia/commit/3a838651dd775651f21c6c6104fc5052280cdd63
-438,1,1,Marco Peereboom,2017-09-06 20:51:34,https://github.com/decred/politeia/commit/c01973d8de5f350be6635361187f307e229bfd52
-439,1,1,Marco Peereboom,2017-08-31 15:45:06,https://github.com/decred/politeia/commit/72b951c28debf532679eb225e67a8790b74cab8d
-440,1,1,Marco Peereboom,2017-08-31 13:01:13,https://github.com/decred/politeia/commit/c5c052f3371ef1b8561eace41299c7fcd4e2d729
-441,1,1,Marco Peereboom,2017-08-29 18:26:40,https://github.com/decred/politeia/commit/7be2b9dd24d68b0c2e7b3dd7a89ee33b1dd10200
-442,1,1,Marco Peereboom,2017-08-29 17:51:38,https://github.com/decred/politeia/commit/f73c0a569c21aec6d5afaa48919fc039a7e0b474
-443,1,1,Marco Peereboom,2017-08-29 13:37:19,https://github.com/decred/politeia/commit/ef12a8a7676f6cb5498aeda91c7d61f876486587
-444,1,1,Sean Durkin,2017-08-29 13:35:16,https://github.com/decred/politeia/commit/7756d103d047b8b6c10a42ab40ecfdc031c0c360
-445,1,1,Marco Peereboom,2017-08-29 13:01:33,https://github.com/decred/politeia/commit/0c44edf0c1e2f5523d1a8e340f3cd8cea0701fee
-446,1,1,Marco Peereboom,2017-08-28 20:50:09,https://github.com/decred/politeia/commit/f721a76268a8bf4d91d12396c4fba6fc853b8ff4
-447,1,1,Marco Peereboom,2017-08-25 21:20:44,https://github.com/decred/politeia/commit/4ad3a71064a77896d21952adac3fd5dd10afd6fc
-448,1,1,Marco Peereboom,2017-08-25 15:37:45,https://github.com/decred/politeia/commit/19dbf27bd1f32d07c8c82a49726a101efb3935b3
-449,1,1,Marco Peereboom,2017-08-24 21:21:58,https://github.com/decred/politeia/commit/08b6c75a5a7baf94621b7834cf25c57d0d3dcf96
-450,1,1,Marco Peereboom,2017-08-24 21:20:47,https://github.com/decred/politeia/commit/3909e28c3bd381f21879507ec57914e79c391e49
-451,1,1,Marco Peereboom,2017-08-24 20:57:53,https://github.com/decred/politeia/commit/054b08774a56c21757769f0225a6af09a86273fc
-452,3,1,camus-code,2019-01-17 17:45:20,https://github.com/decred/politeia/pull/671
-453,3,1,marcopeereboom,2019-01-16 16:14:28,https://github.com/decred/politeia/pull/668
-454,3,1,orthomind,2019-01-12 13:00:47,https://github.com/decred/politeia/pull/667
-455,3,1,victorgcramos,2019-01-08 15:18:35,https://github.com/decred/politeia/pull/663
-456,3,1,lukebp,2019-01-07 13:35:43,https://github.com/decred/politeia/pull/660
-457,3,1,dajohi,2019-01-02 14:48:10,https://github.com/decred/politeia/pull/659
-458,3,1,EvertonMelo,2019-01-01 02:59:26,https://github.com/decred/politeia/pull/658
-459,3,1,fernandoabolafio,2018-12-26 16:07:22,https://github.com/decred/politeia/pull/655
-460,3,1,thi4go,2018-12-22 18:06:02,https://github.com/decred/politeia/pull/649
-461,3,1,lukebp,2018-12-21 16:06:49,https://github.com/decred/politeia/pull/648
-462,3,1,lukebp,2018-12-19 12:26:26,https://github.com/decred/politeia/pull/646
-463,3,1,lukebp,2018-12-19 12:02:28,https://github.com/decred/politeia/pull/645
-464,3,1,thi4go,2018-12-18 11:57:57,https://github.com/decred/politeia/pull/644
-465,3,1,tpkeeper,2018-12-18 08:18:59,https://github.com/decred/politeia/pull/643
-466,3,1,thi4go,2018-12-11 22:27:36,https://github.com/decred/politeia/pull/641
-467,3,1,s-ben,2018-12-08 05:08:54,https://github.com/decred/politeia/pull/640
-468,3,1,davecgh,2018-12-07 18:38:08,https://github.com/decred/politeia/pull/639
-469,3,1,marcopeereboom,2018-12-07 15:56:28,https://github.com/decred/politeia/pull/638
-470,3,1,lukebp,2018-12-07 14:53:15,https://github.com/decred/politeia/pull/637
-471,3,1,dajohi,2018-12-06 21:07:20,https://github.com/decred/politeia/pull/636
-472,3,1,thi4go,2018-12-06 14:34:44,https://github.com/decred/politeia/pull/635
-473,3,1,camus-code,2018-12-05 18:03:11,https://github.com/decred/politeia/pull/634
-474,3,1,lukebp,2018-12-03 16:39:55,https://github.com/decred/politeia/pull/633
-475,3,1,lukebp,2018-12-03 16:17:34,https://github.com/decred/politeia/pull/632
-476,3,1,camus-code,2018-12-03 15:06:19,https://github.com/decred/politeia/pull/631
-477,3,1,s-ben,2018-12-02 07:13:38,https://github.com/decred/politeia/pull/628
-478,3,1,lukebp,2018-11-30 12:12:23,https://github.com/decred/politeia/pull/626
-479,3,1,s-ben,2018-11-29 22:55:25,https://github.com/decred/politeia/pull/625
-480,3,1,fernandoabolafio,2018-11-29 19:45:44,https://github.com/decred/politeia/pull/624
-481,3,1,dajohi,2018-11-29 17:00:39,https://github.com/decred/politeia/pull/623
-482,3,1,lukebp,2018-11-28 18:20:24,https://github.com/decred/politeia/pull/620
-483,3,1,thi4go,2018-11-26 12:00:44,https://github.com/decred/politeia/pull/617
-484,3,1,sndurkin,2018-11-26 02:29:10,https://github.com/decred/politeia/pull/616
-485,3,1,victorgcramos,2018-11-24 18:02:30,https://github.com/decred/politeia/pull/615
-486,3,1,fernandoabolafio,2018-11-21 12:55:55,https://github.com/decred/politeia/pull/613
-487,3,1,fernandoabolafio,2018-11-19 19:08:10,https://github.com/decred/politeia/pull/610
-488,3,1,lukebp,2018-11-19 17:50:32,https://github.com/decred/politeia/pull/609
-489,3,1,victorgcramos,2018-11-18 02:37:00,https://github.com/decred/politeia/pull/606
-490,3,1,lukebp,2018-11-15 21:56:46,https://github.com/decred/politeia/pull/604
-491,3,1,dajohi,2018-11-14 16:05:56,https://github.com/decred/politeia/pull/602
-492,3,1,fernandoabolafio,2018-11-14 13:12:46,https://github.com/decred/politeia/pull/600
-493,3,1,lukebp,2018-11-13 23:48:32,https://github.com/decred/politeia/pull/599
-494,3,1,tiagoalvesdulce,2018-11-13 17:48:47,https://github.com/decred/politeia/pull/598
-495,3,1,thi4go,2018-11-13 12:52:56,https://github.com/decred/politeia/pull/595
-496,3,1,fernandoabolafio,2018-11-12 13:11:00,https://github.com/decred/politeia/pull/594
-497,3,1,lukebp,2018-11-09 18:30:09,https://github.com/decred/politeia/pull/589
-498,3,1,lukebp,2018-11-09 12:54:06,https://github.com/decred/politeia/pull/587
-499,3,1,lukebp,2018-11-09 12:51:16,https://github.com/decred/politeia/pull/586
-500,3,1,degeri,2018-11-08 07:34:15,https://github.com/decred/politeia/pull/584
-501,3,1,fernandoabolafio,2018-11-05 23:52:40,https://github.com/decred/politeia/pull/581
-502,3,1,lukebp,2018-11-02 23:54:02,https://github.com/decred/politeia/pull/579
-503,3,1,sndurkin,2018-11-02 04:26:07,https://github.com/decred/politeia/pull/577
-504,3,1,lukebp,2018-11-01 16:39:20,https://github.com/decred/politeia/pull/574
-505,3,1,dajohi,2018-11-01 02:23:22,https://github.com/decred/politeia/pull/572
-506,3,1,marcopeereboom,2018-10-31 18:45:16,https://github.com/decred/politeia/pull/571
-507,3,1,fernandoabolafio,2018-10-30 20:30:58,https://github.com/decred/politeia/pull/568
-508,3,1,dajohi,2018-10-29 20:07:28,https://github.com/decred/politeia/pull/566
-509,3,1,marcopeereboom,2018-10-25 19:14:34,https://github.com/decred/politeia/pull/559
-510,3,1,dajohi,2018-10-23 19:16:56,https://github.com/decred/politeia/pull/557
-511,3,1,sndurkin,2018-10-23 04:13:24,https://github.com/decred/politeia/pull/553
-512,3,1,lukebp,2018-10-22 20:42:41,https://github.com/decred/politeia/pull/552
-513,3,1,fernandoabolafio,2018-10-22 17:46:05,https://github.com/decred/politeia/pull/551
-514,3,1,lukebp,2018-10-22 14:33:35,https://github.com/decred/politeia/pull/550
-515,3,1,sndurkin,2018-10-21 15:38:29,https://github.com/decred/politeia/pull/549
-516,3,1,lukebp,2018-10-19 16:23:17,https://github.com/decred/politeia/pull/548
-517,3,1,sndurkin,2018-10-18 14:39:20,https://github.com/decred/politeia/pull/542
-518,3,1,sndurkin,2018-10-18 02:09:32,https://github.com/decred/politeia/pull/541
-519,3,1,marcopeereboom,2018-10-17 20:38:42,https://github.com/decred/politeia/pull/540
-520,3,1,sndurkin,2018-10-17 17:00:31,https://github.com/decred/politeia/pull/536
-521,3,1,sndurkin,2018-10-17 03:52:12,https://github.com/decred/politeia/pull/533
-522,3,1,sndurkin,2018-10-17 03:38:03,https://github.com/decred/politeia/pull/532
-523,3,1,marcopeereboom,2018-10-16 19:41:04,https://github.com/decred/politeia/pull/531
-524,3,1,fernandoabolafio,2018-10-16 18:36:46,https://github.com/decred/politeia/pull/530
-525,3,1,sndurkin,2018-10-16 16:21:00,https://github.com/decred/politeia/pull/529
-526,3,1,lukebp,2018-10-16 03:19:09,https://github.com/decred/politeia/pull/526
-527,3,1,marcopeereboom,2018-10-15 21:06:12,https://github.com/decred/politeia/pull/523
-528,3,1,marcopeereboom,2018-10-15 19:56:48,https://github.com/decred/politeia/pull/521
-529,3,1,fernandoabolafio,2018-10-15 19:31:06,https://github.com/decred/politeia/pull/520
-530,3,1,marcopeereboom,2018-10-15 17:37:01,https://github.com/decred/politeia/pull/519
-531,3,1,lukebp,2018-10-15 15:03:58,https://github.com/decred/politeia/pull/518
-532,3,1,fernandoabolafio,2018-10-15 14:31:05,https://github.com/decred/politeia/pull/517
-533,3,1,marcopeereboom,2018-10-12 17:41:35,https://github.com/decred/politeia/pull/516
-534,3,1,tiagoalvesdulce,2018-10-10 23:33:02,https://github.com/decred/politeia/pull/515
-535,3,1,marcopeereboom,2018-10-09 14:46:16,https://github.com/decred/politeia/pull/512
-536,3,1,lukebp,2018-10-08 13:26:48,https://github.com/decred/politeia/pull/510
-537,3,1,marcopeereboom,2018-10-05 20:07:07,https://github.com/decred/politeia/pull/506
-538,3,1,fernandoabolafio,2018-10-04 18:03:58,https://github.com/decred/politeia/pull/504
-539,3,1,lukebp,2018-10-04 17:40:02,https://github.com/decred/politeia/pull/503
-540,3,1,dajohi,2018-10-04 17:25:34,https://github.com/decred/politeia/pull/502
-541,3,1,tiagoalvesdulce,2018-10-03 13:18:25,https://github.com/decred/politeia/pull/497
-542,3,1,lukebp,2018-10-02 19:31:03,https://github.com/decred/politeia/pull/496
-543,3,1,fernandoabolafio,2018-10-02 13:26:10,https://github.com/decred/politeia/pull/495
-544,3,1,wallclockbuilder,2018-10-01 22:10:45,https://github.com/decred/politeia/pull/494
-545,3,1,marcopeereboom,2018-10-01 15:19:11,https://github.com/decred/politeia/pull/493
-546,3,1,fernandoabolafio,2018-09-28 21:33:57,https://github.com/decred/politeia/pull/492
-547,3,1,fernandoabolafio,2018-09-27 22:03:29,https://github.com/decred/politeia/pull/491
-548,3,1,marcopeereboom,2018-09-26 21:45:58,https://github.com/decred/politeia/pull/489
-549,3,1,vctt94,2018-09-26 20:01:22,https://github.com/decred/politeia/pull/488
-550,3,1,marcopeereboom,2018-09-26 19:11:32,https://github.com/decred/politeia/pull/487
-551,3,1,lukebp,2018-09-26 17:06:40,https://github.com/decred/politeia/pull/485
-552,3,1,camus-code,2019-01-17 17:45:20,https://github.com/decred/politeia/pull/671
-553,3,1,victorgcramos,2019-01-08 15:18:35,https://github.com/decred/politeia/pull/663
-554,3,1,lukebp,2019-01-07 13:35:43,https://github.com/decred/politeia/pull/660
-555,3,1,thi4go,2018-12-18 11:57:57,https://github.com/decred/politeia/pull/644
-556,3,1,marcopeereboom,2018-09-13 16:29:01,https://github.com/decred/politeia/pull/469
-557,2,1,camus-code,2019-01-17 17:45:20,https://github.com/decred/politeia/pull/671
-558,2,1,lukebp,2019-01-16 18:25:51,https://github.com/decred/politeia/issues/670
-559,2,1,lukebp,2019-01-16 18:21:54,https://github.com/decred/politeia/issues/669
-560,2,1,marcopeereboom,2019-01-16 16:14:28,https://github.com/decred/politeia/pull/668
-561,2,1,orthomind,2019-01-12 13:00:47,https://github.com/decred/politeia/pull/667
-562,2,1,lemonkabir,2019-01-10 18:07:28,https://github.com/decred/politeia/issues/666
-563,2,1,dajohi,2019-01-09 14:30:00,https://github.com/decred/politeia/issues/665
-564,2,1,marcopeereboom,2019-01-08 17:00:34,https://github.com/decred/politeia/issues/664
-565,2,1,victorgcramos,2019-01-08 15:18:35,https://github.com/decred/politeia/pull/663
-566,2,1,lukebp,2019-01-07 20:09:58,https://github.com/decred/politeia/issues/662
-567,2,1,naichadouban,2019-01-07 15:26:11,https://github.com/decred/politeia/issues/661
-568,2,1,lukebp,2019-01-07 13:35:43,https://github.com/decred/politeia/pull/660
-569,2,1,dajohi,2019-01-02 14:48:10,https://github.com/decred/politeia/pull/659
-570,2,1,EvertonMelo,2019-01-01 02:59:26,https://github.com/decred/politeia/pull/658
-571,2,1,lemonkabir,2018-12-27 14:39:01,https://github.com/decred/politeia/issues/657
-572,2,1,lukebp,2018-12-26 19:39:25,https://github.com/decred/politeia/issues/656
-573,2,1,fernandoabolafio,2018-12-26 16:07:22,https://github.com/decred/politeia/pull/655
-574,2,1,fernandoabolafio,2018-12-26 16:01:35,https://github.com/decred/politeia/issues/654
-575,2,1,tpkeeper,2018-12-24 02:36:21,https://github.com/decred/politeia/issues/653
-576,2,1,lemonkabir,2018-12-22 19:21:05,https://github.com/decred/politeia/issues/652
-577,2,1,lemonkabir,2018-12-22 19:10:20,https://github.com/decred/politeia/issues/651
-578,2,1,lemonkabir,2018-12-22 18:48:19,https://github.com/decred/politeia/issues/650
-579,2,1,thi4go,2018-12-22 18:06:02,https://github.com/decred/politeia/pull/649
-580,2,1,lukebp,2018-12-21 16:06:49,https://github.com/decred/politeia/pull/648
-581,2,1,degeri,2018-12-19 17:04:41,https://github.com/decred/politeia/issues/647
-582,2,1,lukebp,2018-12-19 12:26:26,https://github.com/decred/politeia/pull/646
-583,2,1,lukebp,2018-12-19 12:02:28,https://github.com/decred/politeia/pull/645
-584,2,1,thi4go,2018-12-18 11:57:57,https://github.com/decred/politeia/pull/644
-585,2,1,tpkeeper,2018-12-18 08:18:59,https://github.com/decred/politeia/pull/643
-586,2,1,lukebp,2018-12-13 23:42:33,https://github.com/decred/politeia/issues/642
-587,2,1,thi4go,2018-12-11 22:27:36,https://github.com/decred/politeia/pull/641
-588,2,1,s-ben,2018-12-08 05:08:54,https://github.com/decred/politeia/pull/640
-589,2,1,davecgh,2018-12-07 18:38:08,https://github.com/decred/politeia/pull/639
-590,2,1,marcopeereboom,2018-12-07 15:56:28,https://github.com/decred/politeia/pull/638
-591,2,1,lukebp,2018-12-07 14:53:15,https://github.com/decred/politeia/pull/637
-592,2,1,dajohi,2018-12-06 21:07:20,https://github.com/decred/politeia/pull/636
-593,2,1,thi4go,2018-12-06 14:34:44,https://github.com/decred/politeia/pull/635
-594,2,1,camus-code,2018-12-05 18:03:11,https://github.com/decred/politeia/pull/634
-595,2,1,lukebp,2018-12-03 16:39:55,https://github.com/decred/politeia/pull/633
-596,2,1,lukebp,2018-12-03 16:17:34,https://github.com/decred/politeia/pull/632
-597,2,1,camus-code,2018-12-03 15:06:19,https://github.com/decred/politeia/pull/631
-598,2,1,lukebp,2018-12-03 13:07:21,https://github.com/decred/politeia/issues/630
-599,2,1,degeri,2018-12-02 15:03:21,https://github.com/decred/politeia/issues/629
-600,2,1,s-ben,2018-12-02 07:13:38,https://github.com/decred/politeia/pull/628
-601,2,1,sndurkin,2018-11-30 14:10:12,https://github.com/decred/politeia/issues/627
-602,2,1,lukebp,2018-11-30 12:12:23,https://github.com/decred/politeia/pull/626
-603,2,1,s-ben,2018-11-29 22:55:25,https://github.com/decred/politeia/pull/625
-604,2,1,fernandoabolafio,2018-11-29 19:45:44,https://github.com/decred/politeia/pull/624
-605,2,1,dajohi,2018-11-29 17:00:39,https://github.com/decred/politeia/pull/623
-606,2,1,lukebp,2018-11-29 14:10:23,https://github.com/decred/politeia/issues/622
-607,2,1,lukebp,2018-11-29 13:56:40,https://github.com/decred/politeia/issues/621
-608,2,1,lukebp,2018-11-28 18:20:24,https://github.com/decred/politeia/pull/620
-609,2,1,Michae2xl,2018-11-26 18:46:11,https://github.com/decred/politeia/issues/619
-610,2,1,matheusd,2018-11-26 18:16:07,https://github.com/decred/politeia/issues/618
-611,2,1,thi4go,2018-11-26 12:00:44,https://github.com/decred/politeia/pull/617
-612,2,1,sndurkin,2018-11-26 02:29:10,https://github.com/decred/politeia/pull/616
-613,2,1,victorgcramos,2018-11-24 18:02:30,https://github.com/decred/politeia/pull/615
-614,2,1,lukebp,2018-11-22 16:18:54,https://github.com/decred/politeia/issues/614
-615,2,1,fernandoabolafio,2018-11-21 12:55:55,https://github.com/decred/politeia/pull/613
-616,2,1,brunobraga95,2018-11-20 16:17:10,https://github.com/decred/politeia/issues/612
-617,2,1,oregonisaac,2018-11-20 03:31:58,https://github.com/decred/politeia/issues/611
-618,2,1,fernandoabolafio,2018-11-19 19:08:10,https://github.com/decred/politeia/pull/610
-619,2,1,lukebp,2018-11-19 17:50:32,https://github.com/decred/politeia/pull/609
-620,2,1,degeri,2018-11-19 06:24:56,https://github.com/decred/politeia/issues/608
-621,2,1,degeri,2018-11-19 04:52:18,https://github.com/decred/politeia/issues/607
-622,2,1,victorgcramos,2018-11-18 02:37:00,https://github.com/decred/politeia/pull/606
-623,2,1,dajohi,2018-11-16 15:30:00,https://github.com/decred/politeia/issues/605
-624,2,1,lukebp,2018-11-15 21:56:46,https://github.com/decred/politeia/pull/604
-625,2,1,lukebp,2018-11-15 15:17:35,https://github.com/decred/politeia/issues/603
-626,2,1,dajohi,2018-11-14 16:05:56,https://github.com/decred/politeia/pull/602
-627,2,1,lukebp,2018-11-14 14:33:59,https://github.com/decred/politeia/issues/601
-628,2,1,fernandoabolafio,2018-11-14 13:12:46,https://github.com/decred/politeia/pull/600
-629,2,1,lukebp,2018-11-13 23:48:32,https://github.com/decred/politeia/pull/599
-630,2,1,tiagoalvesdulce,2018-11-13 17:48:47,https://github.com/decred/politeia/pull/598
-631,2,1,tiagoalvesdulce,2018-11-13 17:45:55,https://github.com/decred/politeia/issues/597
-632,2,1,fernandoabolafio,2018-11-13 17:38:57,https://github.com/decred/politeia/issues/596
-633,2,1,thi4go,2018-11-13 12:52:56,https://github.com/decred/politeia/pull/595
-634,2,1,fernandoabolafio,2018-11-12 13:11:00,https://github.com/decred/politeia/pull/594
-635,2,1,xaur,2018-11-11 19:43:58,https://github.com/decred/politeia/issues/593
-636,2,1,xaur,2018-11-11 19:36:22,https://github.com/decred/politeia/issues/592
-637,2,1,xaur,2018-11-11 13:53:18,https://github.com/decred/politeia/issues/591
-638,2,1,jzbz,2018-11-11 02:34:30,https://github.com/decred/politeia/issues/590
-639,2,1,lukebp,2018-11-09 18:30:09,https://github.com/decred/politeia/pull/589
-640,2,1,tiagoalvesdulce,2018-11-09 13:19:56,https://github.com/decred/politeia/issues/588
-641,2,1,lukebp,2018-11-09 12:54:06,https://github.com/decred/politeia/pull/587
-642,2,1,lukebp,2018-11-09 12:51:16,https://github.com/decred/politeia/pull/586
-643,2,1,David00,2018-11-08 21:01:21,https://github.com/decred/politeia/issues/585
-644,2,1,degeri,2018-11-08 07:34:15,https://github.com/decred/politeia/pull/584
-645,2,1,xaur,2018-11-07 19:47:23,https://github.com/decred/politeia/issues/583
-646,2,1,fernandoabolafio,2018-11-07 19:10:16,https://github.com/decred/politeia/issues/582
-647,2,1,fernandoabolafio,2018-11-05 23:52:40,https://github.com/decred/politeia/pull/581
-648,2,1,lukebp,2018-11-05 12:48:10,https://github.com/decred/politeia/issues/580
-649,2,1,lukebp,2018-11-02 23:54:02,https://github.com/decred/politeia/pull/579
-650,2,1,sndurkin,2018-11-02 15:59:55,https://github.com/decred/politeia/issues/578
-651,2,1,sndurkin,2018-11-02 04:26:07,https://github.com/decred/politeia/pull/577
-652,2,1,lukebp,2018-11-01 22:38:32,https://github.com/decred/politeia/issues/576
-653,2,1,davecgh,2018-11-01 20:47:04,https://github.com/decred/politeia/issues/575
-654,2,1,lukebp,2018-11-01 16:39:20,https://github.com/decred/politeia/pull/574
-655,2,1,fernandoabolafio,2018-11-01 15:57:23,https://github.com/decred/politeia/issues/573
-656,2,1,dajohi,2018-11-01 02:23:22,https://github.com/decred/politeia/pull/572
-657,2,1,camus-code,2019-01-17 17:45:20,https://github.com/decred/politeia/pull/671
-658,2,1,lukebp,2019-01-16 18:25:51,https://github.com/decred/politeia/issues/670
-659,2,1,lukebp,2019-01-16 18:21:54,https://github.com/decred/politeia/issues/669
-660,2,1,marcopeereboom,2019-01-16 16:14:28,https://github.com/decred/politeia/pull/668
-661,2,1,orthomind,2019-01-12 13:00:47,https://github.com/decred/politeia/pull/667
-662,2,1,lemonkabir,2019-01-10 18:07:28,https://github.com/decred/politeia/issues/666
-663,2,1,dajohi,2019-01-09 14:30:00,https://github.com/decred/politeia/issues/665
-664,2,1,marcopeereboom,2019-01-08 17:00:34,https://github.com/decred/politeia/issues/664
-665,2,1,victorgcramos,2019-01-08 15:18:35,https://github.com/decred/politeia/pull/663
-666,2,1,lukebp,2019-01-07 20:09:58,https://github.com/decred/politeia/issues/662
-667,2,1,naichadouban,2019-01-07 15:26:11,https://github.com/decred/politeia/issues/661
-668,2,1,lukebp,2019-01-07 13:35:43,https://github.com/decred/politeia/pull/660
-669,2,1,dajohi,2019-01-02 14:48:10,https://github.com/decred/politeia/pull/659
-670,2,1,EvertonMelo,2019-01-01 02:59:26,https://github.com/decred/politeia/pull/658
-671,2,1,lemonkabir,2018-12-27 14:39:01,https://github.com/decred/politeia/issues/657
-672,2,1,lukebp,2018-12-26 19:39:25,https://github.com/decred/politeia/issues/656
-673,2,1,fernandoabolafio,2018-12-26 16:07:22,https://github.com/decred/politeia/pull/655
-674,2,1,fernandoabolafio,2018-12-26 16:01:35,https://github.com/decred/politeia/issues/654
-675,2,1,tpkeeper,2018-12-24 02:36:21,https://github.com/decred/politeia/issues/653
-676,2,1,lemonkabir,2018-12-22 19:21:05,https://github.com/decred/politeia/issues/652
-677,2,1,lemonkabir,2018-12-22 19:10:20,https://github.com/decred/politeia/issues/651
-678,2,1,lemonkabir,2018-12-22 18:48:19,https://github.com/decred/politeia/issues/650
-679,2,1,thi4go,2018-12-22 18:06:02,https://github.com/decred/politeia/pull/649
-680,2,1,lukebp,2018-12-21 16:06:49,https://github.com/decred/politeia/pull/648
-681,2,1,degeri,2018-12-19 17:04:41,https://github.com/decred/politeia/issues/647
-682,2,1,lukebp,2018-12-19 12:26:26,https://github.com/decred/politeia/pull/646
-683,2,1,lukebp,2018-12-19 12:02:28,https://github.com/decred/politeia/pull/645
-684,2,1,thi4go,2018-12-18 11:57:57,https://github.com/decred/politeia/pull/644
-685,2,1,tpkeeper,2018-12-18 08:18:59,https://github.com/decred/politeia/pull/643
-686,2,1,lukebp,2018-12-13 23:42:33,https://github.com/decred/politeia/issues/642
-687,2,1,thi4go,2018-12-11 22:27:36,https://github.com/decred/politeia/pull/641
-688,2,1,s-ben,2018-12-08 05:08:54,https://github.com/decred/politeia/pull/640
-689,2,1,davecgh,2018-12-07 18:38:08,https://github.com/decred/politeia/pull/639
-690,2,1,marcopeereboom,2018-12-07 15:56:28,https://github.com/decred/politeia/pull/638
-691,2,1,lukebp,2018-12-07 14:53:15,https://github.com/decred/politeia/pull/637
-692,2,1,dajohi,2018-12-06 21:07:20,https://github.com/decred/politeia/pull/636
-693,2,1,thi4go,2018-12-06 14:34:44,https://github.com/decred/politeia/pull/635
-694,2,1,camus-code,2018-12-05 18:03:11,https://github.com/decred/politeia/pull/634
-695,2,1,lukebp,2018-12-03 16:39:55,https://github.com/decred/politeia/pull/633
-696,2,1,lukebp,2018-12-03 16:17:34,https://github.com/decred/politeia/pull/632
-697,2,1,camus-code,2018-12-03 15:06:19,https://github.com/decred/politeia/pull/631
-698,2,1,lukebp,2018-12-03 13:07:21,https://github.com/decred/politeia/issues/630
-699,2,1,degeri,2018-12-02 15:03:21,https://github.com/decred/politeia/issues/629
-700,2,1,s-ben,2018-12-02 07:13:38,https://github.com/decred/politeia/pull/628
-701,2,1,sndurkin,2018-11-30 14:10:12,https://github.com/decred/politeia/issues/627
-702,2,1,lukebp,2018-11-30 12:12:23,https://github.com/decred/politeia/pull/626
-703,2,1,s-ben,2018-11-29 22:55:25,https://github.com/decred/politeia/pull/625
-704,2,1,fernandoabolafio,2018-11-29 19:45:44,https://github.com/decred/politeia/pull/624
-705,2,1,dajohi,2018-11-29 17:00:39,https://github.com/decred/politeia/pull/623
-706,2,1,lukebp,2018-11-29 14:10:23,https://github.com/decred/politeia/issues/622
-707,2,1,lukebp,2018-11-29 13:56:40,https://github.com/decred/politeia/issues/621
-708,2,1,lukebp,2018-11-28 18:20:24,https://github.com/decred/politeia/pull/620
-709,2,1,Michae2xl,2018-11-26 18:46:11,https://github.com/decred/politeia/issues/619
-710,2,1,matheusd,2018-11-26 18:16:07,https://github.com/decred/politeia/issues/618
-711,2,1,thi4go,2018-11-26 12:00:44,https://github.com/decred/politeia/pull/617
-712,2,1,sndurkin,2018-11-26 02:29:10,https://github.com/decred/politeia/pull/616
-713,2,1,victorgcramos,2018-11-24 18:02:30,https://github.com/decred/politeia/pull/615
-714,2,1,lukebp,2018-11-22 16:18:54,https://github.com/decred/politeia/issues/614
-715,2,1,fernandoabolafio,2018-11-21 12:55:55,https://github.com/decred/politeia/pull/613
-716,2,1,brunobraga95,2018-11-20 16:17:10,https://github.com/decred/politeia/issues/612
-717,2,1,oregonisaac,2018-11-20 03:31:58,https://github.com/decred/politeia/issues/611
-718,2,1,fernandoabolafio,2018-11-19 19:08:10,https://github.com/decred/politeia/pull/610
-719,2,1,lukebp,2018-11-19 17:50:32,https://github.com/decred/politeia/pull/609
-720,2,1,degeri,2018-11-19 06:24:56,https://github.com/decred/politeia/issues/608
-721,2,1,degeri,2018-11-19 04:52:18,https://github.com/decred/politeia/issues/607
-722,2,1,victorgcramos,2018-11-18 02:37:00,https://github.com/decred/politeia/pull/606
-723,2,1,dajohi,2018-11-16 15:30:00,https://github.com/decred/politeia/issues/605
-724,2,1,lukebp,2018-11-15 21:56:46,https://github.com/decred/politeia/pull/604
-725,2,1,lukebp,2018-11-15 15:17:35,https://github.com/decred/politeia/issues/603
-726,2,1,dajohi,2018-11-14 16:05:56,https://github.com/decred/politeia/pull/602
-727,2,1,lukebp,2018-11-14 14:33:59,https://github.com/decred/politeia/issues/601
-728,2,1,fernandoabolafio,2018-11-14 13:12:46,https://github.com/decred/politeia/pull/600
-729,2,1,lukebp,2018-11-13 23:48:32,https://github.com/decred/politeia/pull/599
-730,2,1,tiagoalvesdulce,2018-11-13 17:48:47,https://github.com/decred/politeia/pull/598
-731,2,1,tiagoalvesdulce,2018-11-13 17:45:55,https://github.com/decred/politeia/issues/597
-732,2,1,fernandoabolafio,2018-11-13 17:38:57,https://github.com/decred/politeia/issues/596
-733,2,1,thi4go,2018-11-13 12:52:56,https://github.com/decred/politeia/pull/595
-734,2,1,fernandoabolafio,2018-11-12 13:11:00,https://github.com/decred/politeia/pull/594
-735,2,1,xaur,2018-11-11 19:43:58,https://github.com/decred/politeia/issues/593
-736,2,1,xaur,2018-11-11 19:36:22,https://github.com/decred/politeia/issues/592
-737,2,1,xaur,2018-11-11 13:53:18,https://github.com/decred/politeia/issues/591
-738,2,1,jzbz,2018-11-11 02:34:30,https://github.com/decred/politeia/issues/590
-739,2,1,lukebp,2018-11-09 18:30:09,https://github.com/decred/politeia/pull/589
-740,2,1,tiagoalvesdulce,2018-11-09 13:19:56,https://github.com/decred/politeia/issues/588
-741,2,1,lukebp,2018-11-09 12:54:06,https://github.com/decred/politeia/pull/587
-742,2,1,lukebp,2018-11-09 12:51:16,https://github.com/decred/politeia/pull/586
-743,2,1,David00,2018-11-08 21:01:21,https://github.com/decred/politeia/issues/585
-744,2,1,degeri,2018-11-08 07:34:15,https://github.com/decred/politeia/pull/584
-745,2,1,xaur,2018-11-07 19:47:23,https://github.com/decred/politeia/issues/583
-746,2,1,fernandoabolafio,2018-11-07 19:10:16,https://github.com/decred/politeia/issues/582
-747,2,1,fernandoabolafio,2018-11-05 23:52:40,https://github.com/decred/politeia/pull/581
-748,2,1,lukebp,2018-11-05 12:48:10,https://github.com/decred/politeia/issues/580
-749,2,1,lukebp,2018-11-02 23:54:02,https://github.com/decred/politeia/pull/579
-750,2,1,sndurkin,2018-11-02 15:59:55,https://github.com/decred/politeia/issues/578
-751,2,1,sndurkin,2018-11-02 04:26:07,https://github.com/decred/politeia/pull/577
-752,2,1,lukebp,2018-11-01 22:38:32,https://github.com/decred/politeia/issues/576
-753,2,1,davecgh,2018-11-01 20:47:04,https://github.com/decred/politeia/issues/575
-754,2,1,lukebp,2018-11-01 16:39:20,https://github.com/decred/politeia/pull/574
-755,2,1,fernandoabolafio,2018-11-01 15:57:23,https://github.com/decred/politeia/issues/573
-756,2,1,dajohi,2018-11-01 02:23:22,https://github.com/decred/politeia/pull/572
-757,2,1,marcopeereboom,2018-10-31 18:45:16,https://github.com/decred/politeia/pull/571
-758,2,1,xaur,2018-10-31 17:58:17,https://github.com/decred/politeia/issues/570
-759,2,1,xaur,2018-10-30 22:36:09,https://github.com/decred/politeia/issues/569
-760,2,1,fernandoabolafio,2018-10-30 20:30:58,https://github.com/decred/politeia/pull/568
-761,2,1,davecgh,2018-10-30 00:40:42,https://github.com/decred/politeia/issues/567
-762,2,1,dajohi,2018-10-29 20:07:28,https://github.com/decred/politeia/pull/566
-763,2,1,davecgh,2018-10-29 19:37:21,https://github.com/decred/politeia/issues/565
-764,2,1,fernandoabolafio,2018-10-29 13:49:14,https://github.com/decred/politeia/issues/564
-765,2,1,lukebp,2018-10-27 21:07:28,https://github.com/decred/politeia/issues/563
-766,2,1,davecgh,2018-10-26 18:07:15,https://github.com/decred/politeia/issues/562
-767,2,1,degeri,2018-10-26 14:54:17,https://github.com/decred/politeia/issues/561
-768,2,1,xaur,2018-10-26 10:13:48,https://github.com/decred/politeia/issues/560
-769,2,1,marcopeereboom,2018-10-25 19:14:34,https://github.com/decred/politeia/pull/559
-770,2,1,xaur,2018-10-25 19:08:11,https://github.com/decred/politeia/issues/558
-771,2,1,dajohi,2018-10-23 19:16:56,https://github.com/decred/politeia/pull/557
-772,2,1,dajohi,2018-10-23 19:00:13,https://github.com/decred/politeia/issues/556
-773,2,1,fernandoabolafio,2018-10-23 14:15:17,https://github.com/decred/politeia/issues/555
-774,2,1,xaur,2018-10-23 11:21:38,https://github.com/decred/politeia/issues/554
-775,2,1,sndurkin,2018-10-23 04:13:24,https://github.com/decred/politeia/pull/553
-776,2,1,lukebp,2018-10-22 20:42:41,https://github.com/decred/politeia/pull/552
-777,2,1,fernandoabolafio,2018-10-22 17:46:05,https://github.com/decred/politeia/pull/551
-778,2,1,lukebp,2018-10-22 14:33:35,https://github.com/decred/politeia/pull/550
-779,2,1,sndurkin,2018-10-21 15:38:29,https://github.com/decred/politeia/pull/549
-780,2,1,lukebp,2018-10-19 16:23:17,https://github.com/decred/politeia/pull/548
-781,2,1,marcopeereboom,2018-10-18 19:19:12,https://github.com/decred/politeia/issues/547
-782,2,1,marcopeereboom,2018-10-18 18:55:01,https://github.com/decred/politeia/issues/546
-783,2,1,marcopeereboom,2018-10-18 18:40:06,https://github.com/decred/politeia/issues/545
-784,2,1,marcopeereboom,2018-10-18 18:30:12,https://github.com/decred/politeia/issues/544
-785,2,1,marcopeereboom,2018-10-18 17:58:27,https://github.com/decred/politeia/issues/543
-786,2,1,sndurkin,2018-10-18 14:39:20,https://github.com/decred/politeia/pull/542
-787,2,1,sndurkin,2018-10-18 02:09:32,https://github.com/decred/politeia/pull/541
-788,2,1,marcopeereboom,2018-10-17 20:38:42,https://github.com/decred/politeia/pull/540
-789,2,1,marcopeereboom,2018-10-17 19:29:36,https://github.com/decred/politeia/issues/539
-790,2,1,marcopeereboom,2018-10-17 17:22:47,https://github.com/decred/politeia/issues/538
-791,2,1,marcopeereboom,2018-10-17 17:17:44,https://github.com/decred/politeia/issues/537
-792,2,1,sndurkin,2018-10-17 17:00:31,https://github.com/decred/politeia/pull/536
-793,2,1,marcopeereboom,2018-10-17 16:32:08,https://github.com/decred/politeia/issues/535
-794,2,1,RichardRed0x,2018-10-17 14:21:59,https://github.com/decred/politeia/issues/534
-795,2,1,sndurkin,2018-10-17 03:52:12,https://github.com/decred/politeia/pull/533
-796,2,1,sndurkin,2018-10-17 03:38:03,https://github.com/decred/politeia/pull/532
-797,2,1,marcopeereboom,2018-10-16 19:41:04,https://github.com/decred/politeia/pull/531
-798,2,1,fernandoabolafio,2018-10-16 18:36:46,https://github.com/decred/politeia/pull/530
-799,2,1,sndurkin,2018-10-16 16:21:00,https://github.com/decred/politeia/pull/529
-800,2,1,sndurkin,2018-10-16 15:02:43,https://github.com/decred/politeia/issues/528
-801,2,1,marcopeereboom,2018-10-16 13:34:00,https://github.com/decred/politeia/issues/527
-802,2,1,lukebp,2018-10-16 03:19:09,https://github.com/decred/politeia/pull/526
-803,2,1,lukebp,2018-10-16 01:26:15,https://github.com/decred/politeia/issues/525
-804,2,1,marcopeereboom,2018-10-15 21:23:07,https://github.com/decred/politeia/issues/524
-805,2,1,marcopeereboom,2018-10-15 21:06:12,https://github.com/decred/politeia/pull/523
-806,2,1,lukebp,2018-10-15 20:10:03,https://github.com/decred/politeia/issues/522
-807,2,1,marcopeereboom,2018-10-15 19:56:48,https://github.com/decred/politeia/pull/521
-808,2,1,fernandoabolafio,2018-10-15 19:31:06,https://github.com/decred/politeia/pull/520
-809,2,1,marcopeereboom,2018-10-15 17:37:01,https://github.com/decred/politeia/pull/519
-810,2,1,lukebp,2018-10-15 15:03:58,https://github.com/decred/politeia/pull/518
-811,2,1,fernandoabolafio,2018-10-15 14:31:05,https://github.com/decred/politeia/pull/517
-812,2,1,marcopeereboom,2018-10-12 17:41:35,https://github.com/decred/politeia/pull/516
-813,2,1,tiagoalvesdulce,2018-10-10 23:33:02,https://github.com/decred/politeia/pull/515
-814,2,1,tiagoalvesdulce,2018-10-10 20:55:01,https://github.com/decred/politeia/issues/514
-815,2,1,matheusd,2018-10-10 11:10:59,https://github.com/decred/politeia/issues/513
-816,2,1,marcopeereboom,2018-10-09 14:46:16,https://github.com/decred/politeia/pull/512
-817,2,1,fernandoabolafio,2018-10-08 14:14:28,https://github.com/decred/politeia/issues/511
-818,2,1,lukebp,2018-10-08 13:26:48,https://github.com/decred/politeia/pull/510
-819,2,1,fernandoabolafio,2018-10-05 21:35:25,https://github.com/decred/politeia/issues/509
-820,2,1,lukebp,2018-10-05 21:15:41,https://github.com/decred/politeia/issues/508
-821,2,1,marcopeereboom,2018-10-05 21:05:43,https://github.com/decred/politeia/issues/507
-822,2,1,marcopeereboom,2018-10-05 20:07:07,https://github.com/decred/politeia/pull/506
-823,2,1,lukebp,2018-10-04 20:47:06,https://github.com/decred/politeia/issues/505
-824,2,1,fernandoabolafio,2018-10-04 18:03:58,https://github.com/decred/politeia/pull/504
-825,2,1,lukebp,2018-10-04 17:40:02,https://github.com/decred/politeia/pull/503
-826,2,1,dajohi,2018-10-04 17:25:34,https://github.com/decred/politeia/pull/502
-827,2,1,dajohi,2018-10-04 16:06:29,https://github.com/decred/politeia/issues/501
-828,2,1,marcopeereboom,2018-10-03 22:20:19,https://github.com/decred/politeia/issues/500
-829,2,1,degeri,2018-10-03 17:47:22,https://github.com/decred/politeia/issues/499
-830,2,1,fernandoabolafio,2018-10-03 14:45:13,https://github.com/decred/politeia/issues/498
-831,2,1,tiagoalvesdulce,2018-10-03 13:18:25,https://github.com/decred/politeia/pull/497
-832,2,1,lukebp,2018-10-02 19:31:03,https://github.com/decred/politeia/pull/496
-833,2,1,fernandoabolafio,2018-10-02 13:26:10,https://github.com/decred/politeia/pull/495
-834,2,1,wallclockbuilder,2018-10-01 22:10:45,https://github.com/decred/politeia/pull/494
-835,2,1,marcopeereboom,2018-10-01 15:19:11,https://github.com/decred/politeia/pull/493
-836,2,1,fernandoabolafio,2018-09-28 21:33:57,https://github.com/decred/politeia/pull/492
-837,2,1,fernandoabolafio,2018-09-27 22:03:29,https://github.com/decred/politeia/pull/491
-838,2,1,marcopeereboom,2018-09-27 13:09:06,https://github.com/decred/politeia/issues/490
-839,2,1,marcopeereboom,2018-09-26 21:45:58,https://github.com/decred/politeia/pull/489
-840,2,1,vctt94,2018-09-26 20:01:22,https://github.com/decred/politeia/pull/488
-841,2,1,marcopeereboom,2018-09-26 19:11:32,https://github.com/decred/politeia/pull/487
-842,2,1,marcopeereboom,2018-09-26 19:11:03,https://github.com/decred/politeia/issues/486
-843,2,1,lukebp,2018-09-26 17:06:40,https://github.com/decred/politeia/pull/485
-844,2,1,thi4go,2018-09-25 21:16:24,https://github.com/decred/politeia/pull/484
-845,2,1,lukebp,2018-09-25 15:18:30,https://github.com/decred/politeia/pull/483
-846,2,1,fernandoabolafio,2018-09-24 20:15:29,https://github.com/decred/politeia/pull/482
-847,2,1,camus-code,2018-09-24 17:59:13,https://github.com/decred/politeia/issues/481
-848,2,1,lukebp,2018-09-24 15:44:47,https://github.com/decred/politeia/pull/480
-849,2,1,marcopeereboom,2018-09-24 14:31:57,https://github.com/decred/politeia/issues/479
-850,2,1,degeri,2018-09-21 19:41:01,https://github.com/decred/politeia/issues/478
-851,2,1,dajohi,2018-09-21 17:51:07,https://github.com/decred/politeia/pull/477
-852,2,1,lukebp,2018-09-21 13:59:47,https://github.com/decred/politeia/pull/476
-853,2,1,lukebp,2018-09-20 14:22:56,https://github.com/decred/politeia/pull/475
-854,2,1,lukebp,2018-09-20 13:21:40,https://github.com/decred/politeia/issues/474
-855,2,1,lukebp,2018-09-19 20:07:16,https://github.com/decred/politeia/pull/473
-856,2,1,lukebp,2018-09-18 21:03:51,https://github.com/decred/politeia/pull/472
-857,2,1,dajohi,2018-09-18 20:40:05,https://github.com/decred/politeia/pull/471
-858,2,1,lukebp,2018-09-18 15:54:15,https://github.com/decred/politeia/pull/470
-859,2,1,marcopeereboom,2018-09-13 16:29:01,https://github.com/decred/politeia/pull/469
-860,2,1,thi4go,2018-09-12 23:02:02,https://github.com/decred/politeia/pull/468
-861,2,1,s-ben,2018-09-12 18:21:06,https://github.com/decred/politeia/pull/467
-862,2,1,lukebp,2018-09-11 19:53:58,https://github.com/decred/politeia/pull/466
-863,2,1,fernandoabolafio,2018-09-11 17:49:21,https://github.com/decred/politeia/pull/465
-864,2,1,fernandoabolafio,2018-09-11 15:07:54,https://github.com/decred/politeia/pull/464
-865,2,1,lukebp,2018-09-11 11:22:46,https://github.com/decred/politeia/issues/463
-866,2,1,tiagoalvesdulce,2018-09-10 18:28:59,https://github.com/decred/politeia/issues/462
-867,2,1,fernandoabolafio,2018-09-10 18:00:26,https://github.com/decred/politeia/issues/461
-868,2,1,lukebp,2018-09-10 14:18:05,https://github.com/decred/politeia/pull/460
-869,2,1,tiagoalvesdulce,2018-09-07 19:37:47,https://github.com/decred/politeia/issues/459
-870,2,1,marcopeereboom,2018-09-07 18:58:53,https://github.com/decred/politeia/pull/458
-871,2,1,tiagoalvesdulce,2018-09-07 15:57:21,https://github.com/decred/politeia/pull/457
-872,2,1,marcopeereboom,2018-09-06 19:33:09,https://github.com/decred/politeia/issues/456
-873,2,1,lukebp,2018-09-06 14:14:54,https://github.com/decred/politeia/pull/455
-874,2,1,lukebp,2018-09-06 13:22:48,https://github.com/decred/politeia/issues/454
-875,2,1,lukebp,2018-09-06 00:08:29,https://github.com/decred/politeia/issues/453
-876,2,1,fernandoabolafio,2018-09-05 19:35:04,https://github.com/decred/politeia/pull/452
-877,2,1,lukebp,2018-09-05 17:22:06,https://github.com/decred/politeia/pull/451
-878,2,1,marcopeereboom,2018-09-05 16:26:54,https://github.com/decred/politeia/issues/450
-879,2,1,marcopeereboom,2018-09-05 16:14:49,https://github.com/decred/politeia/issues/449
-880,2,1,marcopeereboom,2018-09-05 16:09:21,https://github.com/decred/politeia/issues/448
-881,2,1,marcopeereboom,2018-09-05 14:42:12,https://github.com/decred/politeia/issues/447
-882,2,1,marcopeereboom,2018-09-05 14:28:35,https://github.com/decred/politeia/issues/446
-883,2,1,marcopeereboom,2018-09-05 14:26:12,https://github.com/decred/politeia/issues/445
-884,2,1,marcopeereboom,2018-09-05 13:55:17,https://github.com/decred/politeia/issues/444
-885,2,1,lukebp,2018-09-05 12:10:11,https://github.com/decred/politeia/pull/443
-886,2,1,lukebp,2018-09-04 23:32:46,https://github.com/decred/politeia/pull/442
-887,2,1,RichardRed0x,2018-09-04 23:21:00,https://github.com/decred/politeia/issues/441
-888,2,1,tiagoalvesdulce,2018-09-04 18:04:50,https://github.com/decred/politeia/pull/440
-889,2,1,fernandoabolafio,2018-09-04 13:44:04,https://github.com/decred/politeia/pull/439
-890,2,1,fernandoabolafio,2018-09-03 22:42:14,https://github.com/decred/politeia/pull/438
-891,2,1,fernandoabolafio,2018-08-31 20:14:29,https://github.com/decred/politeia/pull/437
-892,2,1,dajohi,2018-08-31 13:54:02,https://github.com/decred/politeia/pull/436
-893,2,1,fernandoabolafio,2018-08-31 13:15:16,https://github.com/decred/politeia/pull/435
-894,2,1,dajohi,2018-08-30 15:39:09,https://github.com/decred/politeia/pull/434
-895,2,1,marcopeereboom,2018-08-30 14:26:26,https://github.com/decred/politeia/pull/433
-896,2,1,lukebp,2018-08-30 14:20:54,https://github.com/decred/politeia/pull/432
-897,2,1,dajohi,2018-08-29 20:13:25,https://github.com/decred/politeia/pull/431
-898,2,1,vctt94,2018-08-29 18:46:18,https://github.com/decred/politeia/pull/430
-899,2,1,fernandoabolafio,2018-08-29 16:10:35,https://github.com/decred/politeia/pull/429
-900,2,1,fernandoabolafio,2018-08-29 14:42:38,https://github.com/decred/politeia/pull/428
-901,2,1,marcopeereboom,2018-08-28 22:06:29,https://github.com/decred/politeia/issues/427
-902,2,1,marcopeereboom,2018-08-28 22:00:31,https://github.com/decred/politeia/issues/426
-903,2,1,fernandoabolafio,2018-08-24 17:20:20,https://github.com/decred/politeia/pull/425
-904,2,1,fernandoabolafio,2018-08-15 22:27:55,https://github.com/decred/politeia/pull/424
-905,2,1,lukebp,2018-08-13 20:38:07,https://github.com/decred/politeia/pull/423
-906,2,1,lukebp,2018-08-10 21:18:41,https://github.com/decred/politeia/pull/422
-907,2,1,lukebp,2018-08-10 21:09:02,https://github.com/decred/politeia/issues/421
-908,2,1,marcopeereboom,2018-08-10 17:03:35,https://github.com/decred/politeia/pull/420
-909,2,1,sndurkin,2018-08-09 03:21:22,https://github.com/decred/politeia/pull/419
-910,2,1,sndurkin,2018-08-08 21:17:44,https://github.com/decred/politeia/pull/418
-911,2,1,dajohi,2018-08-08 17:54:47,https://github.com/decred/politeia/pull/417
-912,2,1,fernandoabolafio,2018-08-06 20:48:51,https://github.com/decred/politeia/issues/416
-913,2,1,fernandoabolafio,2018-08-06 20:28:29,https://github.com/decred/politeia/pull/415
-914,2,1,degeri,2018-08-04 14:07:00,https://github.com/decred/politeia/issues/414
-915,2,1,sndurkin,2018-08-02 14:12:00,https://github.com/decred/politeia/pull/413
-916,2,1,sndurkin,2018-08-02 03:56:39,https://github.com/decred/politeia/pull/412
-917,2,1,sndurkin,2018-08-01 16:36:26,https://github.com/decred/politeia/pull/411
-918,2,1,sndurkin,2018-08-01 05:17:40,https://github.com/decred/politeia/pull/410
-919,2,1,lukebp,2018-08-01 00:49:28,https://github.com/decred/politeia/pull/409
-920,2,1,lukebp,2018-07-30 12:45:06,https://github.com/decred/politeia/pull/408
-921,2,1,sndurkin,2018-07-27 19:20:50,https://github.com/decred/politeia/issues/407
-922,2,1,lukebp,2018-07-25 17:37:21,https://github.com/decred/politeia/pull/406
-923,2,1,lukebp,2018-07-25 17:36:20,https://github.com/decred/politeia/issues/405
-924,2,1,vctt94,2018-07-25 13:41:05,https://github.com/decred/politeia/pull/404
-925,2,1,sndurkin,2018-07-24 13:58:13,https://github.com/decred/politeia/issues/403
-926,2,1,hsanjuan,2018-07-23 22:54:39,https://github.com/decred/politeia/issues/402
-927,2,1,hsanjuan,2018-07-23 22:50:12,https://github.com/decred/politeia/pull/401
-928,2,1,fernandoabolafio,2018-07-23 16:26:38,https://github.com/decred/politeia/pull/400
-929,2,1,lukebp,2018-07-21 19:08:15,https://github.com/decred/politeia/issues/399
-930,2,1,lukebp,2018-07-21 18:52:30,https://github.com/decred/politeia/pull/398
-931,2,1,lukebp,2018-07-21 17:37:08,https://github.com/decred/politeia/issues/397
-932,2,1,fernandoabolafio,2018-07-21 13:59:55,https://github.com/decred/politeia/issues/396
-933,2,1,fernandoabolafio,2018-07-20 20:32:27,https://github.com/decred/politeia/pull/395
-934,2,1,vctt94,2018-07-19 15:37:38,https://github.com/decred/politeia/pull/394
-935,2,1,fernandoabolafio,2018-07-18 21:43:30,https://github.com/decred/politeia/pull/393
-936,2,1,sndurkin,2018-07-18 04:45:55,https://github.com/decred/politeia/pull/392
-937,2,1,lukebp,2018-07-17 23:43:13,https://github.com/decred/politeia/pull/391
-938,2,1,sndurkin,2018-07-17 18:27:35,https://github.com/decred/politeia/pull/390
-939,2,1,sndurkin,2018-07-16 03:30:54,https://github.com/decred/politeia/pull/389
-940,2,1,rrecuero,2018-07-15 20:49:57,https://github.com/decred/politeia/issues/388
-941,2,1,marcopeereboom,2018-07-13 12:01:03,https://github.com/decred/politeia/pull/387
-942,2,1,fernandoabolafio,2018-07-13 10:51:40,https://github.com/decred/politeia/pull/386
-943,2,1,sndurkin,2018-07-13 03:01:46,https://github.com/decred/politeia/pull/385
-944,2,1,sndurkin,2018-07-12 16:45:43,https://github.com/decred/politeia/issues/384
-945,2,1,sndurkin,2018-07-12 16:33:07,https://github.com/decred/politeia/issues/383
-946,2,1,vctt94,2018-07-12 15:50:00,https://github.com/decred/politeia/pull/382
-947,2,1,marcopeereboom,2018-07-12 10:55:52,https://github.com/decred/politeia/issues/381
-948,2,1,sndurkin,2018-07-12 04:07:39,https://github.com/decred/politeia/issues/380
-949,2,1,dajohi,2018-07-11 20:25:19,https://github.com/decred/politeia/issues/379
-950,2,1,dajohi,2018-07-11 20:09:29,https://github.com/decred/politeia/pull/378
-951,2,1,dajohi,2018-07-11 19:01:09,https://github.com/decred/politeia/issues/377
-952,2,1,fernandoabolafio,2018-07-09 11:44:41,https://github.com/decred/politeia/issues/376
-953,2,1,sndurkin,2018-07-06 22:58:27,https://github.com/decred/politeia/pull/375
-954,2,1,vctt94,2018-07-06 15:48:17,https://github.com/decred/politeia/pull/374
-955,2,1,sndurkin,2018-07-06 13:19:58,https://github.com/decred/politeia/pull/373
-956,2,1,fernandoabolafio,2018-07-05 20:09:49,https://github.com/decred/politeia/issues/372
-957,2,1,tiagoalvesdulce,2018-07-03 19:22:04,https://github.com/decred/politeia/pull/371
-958,2,1,fernandoabolafio,2018-07-03 18:52:19,https://github.com/decred/politeia/pull/370
-959,2,1,tiagoalvesdulce,2018-07-03 16:55:56,https://github.com/decred/politeia/issues/369
-960,2,1,sndurkin,2018-07-03 16:01:52,https://github.com/decred/politeia/issues/368
-961,2,1,marcopeereboom,2018-07-03 13:02:12,https://github.com/decred/politeia/pull/367
-962,2,1,marcopeereboom,2018-07-03 12:11:05,https://github.com/decred/politeia/issues/366
-963,2,1,marcopeereboom,2018-07-03 10:44:59,https://github.com/decred/politeia/pull/365
-964,2,1,marcopeereboom,2018-07-03 10:44:01,https://github.com/decred/politeia/issues/364
-965,2,1,tiagoalvesdulce,2018-07-02 20:25:27,https://github.com/decred/politeia/pull/363
-966,2,1,fernandoabolafio,2018-07-02 16:28:22,https://github.com/decred/politeia/issues/362
-967,2,1,rrecuero,2018-07-02 00:32:52,https://github.com/decred/politeia/pull/361
-968,2,1,sndurkin,2018-06-30 02:32:16,https://github.com/decred/politeia/pull/360
-969,2,1,sndurkin,2018-06-28 14:05:58,https://github.com/decred/politeia/pull/359
-970,2,1,marcopeereboom,2018-06-28 12:11:02,https://github.com/decred/politeia/issues/358
-971,2,1,RichardRed0x,2018-06-28 12:10:10,https://github.com/decred/politeia/issues/357
-972,2,1,RichardRed0x,2018-06-28 09:41:58,https://github.com/decred/politeia/issues/356
-973,2,1,tiagoalvesdulce,2018-06-26 19:01:37,https://github.com/decred/politeia/issues/355
-974,2,1,fernandoabolafio,2018-06-26 15:30:16,https://github.com/decred/politeia/issues/354
-975,2,1,tiagoalvesdulce,2018-06-26 01:40:08,https://github.com/decred/politeia/issues/353
-976,2,1,tiagoalvesdulce,2018-06-25 19:24:54,https://github.com/decred/politeia/pull/352
-977,2,1,sndurkin,2018-06-25 15:00:38,https://github.com/decred/politeia/pull/351
-978,2,1,fernandoabolafio,2018-06-22 17:52:29,https://github.com/decred/politeia/issues/350
-979,2,1,sndurkin,2018-06-22 16:55:03,https://github.com/decred/politeia/issues/349
-980,2,1,RichardRed0x,2018-06-22 14:31:46,https://github.com/decred/politeia/pull/348
-981,2,1,marcopeereboom,2018-06-22 10:42:40,https://github.com/decred/politeia/issues/347
-982,2,1,marcopeereboom,2018-06-22 10:39:43,https://github.com/decred/politeia/issues/346
-983,2,1,sndurkin,2018-06-22 03:57:51,https://github.com/decred/politeia/pull/345
-984,2,1,lukebp,2018-06-21 21:51:51,https://github.com/decred/politeia/pull/344
-985,2,1,fernandoabolafio,2018-06-21 17:16:41,https://github.com/decred/politeia/issues/343
-986,2,1,sndurkin,2018-06-21 16:32:49,https://github.com/decred/politeia/pull/342
-987,2,1,fernandoabolafio,2018-06-21 16:00:42,https://github.com/decred/politeia/pull/341
-988,2,1,fernandoabolafio,2018-06-21 13:08:15,https://github.com/decred/politeia/issues/340
-989,2,1,RichardRed0x,2018-06-21 05:10:44,https://github.com/decred/politeia/issues/339
-990,2,1,sndurkin,2018-06-21 04:41:31,https://github.com/decred/politeia/pull/338
-991,2,1,chappjc,2018-06-20 23:53:33,https://github.com/decred/politeia/pull/337
-992,2,1,fernandoabolafio,2018-06-20 20:30:24,https://github.com/decred/politeia/pull/336
-993,2,1,fernandoabolafio,2018-06-20 19:39:47,https://github.com/decred/politeia/issues/335
-994,2,1,fernandoabolafio,2018-06-20 13:44:59,https://github.com/decred/politeia/pull/334
-995,2,1,marcopeereboom,2018-06-20 13:12:21,https://github.com/decred/politeia/pull/333
-996,2,1,fernandoabolafio,2018-06-19 20:31:10,https://github.com/decred/politeia/issues/332
-997,2,1,fernandoabolafio,2018-06-18 21:51:59,https://github.com/decred/politeia/pull/331
-998,2,1,tiagoalvesdulce,2018-06-18 14:45:35,https://github.com/decred/politeia/issues/330
-999,2,1,marcopeereboom,2018-06-18 11:14:52,https://github.com/decred/politeia/pull/329
-1000,2,1,marcopeereboom,2018-06-15 12:57:41,https://github.com/decred/politeia/pull/328
-1001,2,1,lukebp,2018-06-15 04:40:43,https://github.com/decred/politeia/pull/327
-1002,2,1,tiagoalvesdulce,2018-06-14 17:55:39,https://github.com/decred/politeia/pull/326
-1003,2,1,tiagoalvesdulce,2018-06-13 20:21:44,https://github.com/decred/politeia/issues/325
-1004,2,1,dajohi,2018-06-13 18:36:50,https://github.com/decred/politeia/issues/324
-1005,2,1,marcopeereboom,2018-06-13 15:37:18,https://github.com/decred/politeia/pull/323
-1006,2,1,marcopeereboom,2018-06-13 15:10:41,https://github.com/decred/politeia/pull/322
-1007,2,1,decebal,2018-06-13 10:43:57,https://github.com/decred/politeia/pull/321
-1008,2,1,fernandoabolafio,2018-06-12 20:21:38,https://github.com/decred/politeia/pull/320
-1009,2,1,sndurkin,2018-06-12 17:40:16,https://github.com/decred/politeia/issues/319
-1010,2,1,vctt94,2018-06-11 18:00:32,https://github.com/decred/politeia/pull/318
-1011,2,1,marcopeereboom,2018-06-11 12:47:58,https://github.com/decred/politeia/issues/317
-1012,2,1,marcopeereboom,2018-06-11 11:25:04,https://github.com/decred/politeia/pull/316
-1013,2,1,marcopeereboom,2018-06-11 09:56:52,https://github.com/decred/politeia/issues/315
-1014,2,1,marcopeereboom,2018-06-11 09:24:32,https://github.com/decred/politeia/issues/314
-1015,2,1,marcopeereboom,2018-06-11 08:54:34,https://github.com/decred/politeia/issues/313
-1016,2,1,fernandoabolafio,2018-06-09 17:29:44,https://github.com/decred/politeia/issues/312
-1017,2,1,dajohi,2018-06-07 20:03:34,https://github.com/decred/politeia/pull/311
-1018,2,1,lukebp,2018-06-06 16:14:02,https://github.com/decred/politeia/issues/310
-1019,2,1,sndurkin,2018-06-06 04:22:01,https://github.com/decred/politeia/pull/309
-1020,2,1,lukebp,2018-06-04 19:29:53,https://github.com/decred/politeia/issues/308
-1021,2,1,lukebp,2018-06-03 18:21:09,https://github.com/decred/politeia/pull/307
-1022,2,1,sndurkin,2018-06-01 17:42:26,https://github.com/decred/politeia/issues/306
-1023,2,1,sndurkin,2018-05-31 04:29:18,https://github.com/decred/politeia/pull/305
-1024,2,1,lukebp,2018-05-31 01:08:28,https://github.com/decred/politeia/pull/304
-1025,2,1,sndurkin,2018-05-30 21:44:39,https://github.com/decred/politeia/pull/303
-1026,2,1,sndurkin,2018-05-30 03:02:42,https://github.com/decred/politeia/pull/302
-1027,2,1,sndurkin,2018-05-30 02:18:37,https://github.com/decred/politeia/pull/301
-1028,2,1,fernandoabolafio,2018-05-25 19:57:53,https://github.com/decred/politeia/pull/300
-1029,2,1,marcopeereboom,2018-05-25 19:09:18,https://github.com/decred/politeia/issues/299
-1030,2,1,fernandoabolafio,2018-05-24 22:52:06,https://github.com/decred/politeia/issues/298
-1031,2,1,marcopeereboom,2018-05-24 18:39:06,https://github.com/decred/politeia/pull/297
-1032,2,1,marcopeereboom,2018-05-24 13:43:07,https://github.com/decred/politeia/issues/296
-1033,2,1,marcopeereboom,2018-05-24 13:41:23,https://github.com/decred/politeia/issues/295
-1034,2,1,lukebp,2018-05-24 05:37:54,https://github.com/decred/politeia/pull/294
-1035,2,1,lukebp,2018-05-24 05:08:09,https://github.com/decred/politeia/issues/293
-1036,2,1,lukebp,2018-05-24 05:01:30,https://github.com/decred/politeia/pull/292
-1037,2,1,lukebp,2018-05-24 05:00:07,https://github.com/decred/politeia/issues/291
-1038,2,1,sndurkin,2018-05-23 14:44:44,https://github.com/decred/politeia/pull/290
-1039,2,1,lte13,2018-05-21 07:07:56,https://github.com/decred/politeia/pull/289
-1040,2,1,sndurkin,2018-05-17 03:00:52,https://github.com/decred/politeia/issues/288
-1041,2,1,fernandoabolafio,2018-05-16 14:28:12,https://github.com/decred/politeia/issues/287
-1042,2,1,fernandoabolafio,2018-05-15 21:21:06,https://github.com/decred/politeia/pull/286
-1043,2,1,fernandoabolafio,2018-05-15 19:15:40,https://github.com/decred/politeia/issues/285
-1044,2,1,fernandoabolafio,2018-05-15 14:12:42,https://github.com/decred/politeia/pull/284
-1045,2,1,sndurkin,2018-05-15 03:08:07,https://github.com/decred/politeia/pull/283
-1046,2,1,sndurkin,2018-05-15 02:59:51,https://github.com/decred/politeia/pull/282
-1047,2,1,decebal,2018-05-13 22:51:12,https://github.com/decred/politeia/pull/281
-1048,2,1,lukebp,2018-05-11 18:06:58,https://github.com/decred/politeia/issues/280
-1049,2,1,dajohi,2018-05-10 18:16:35,https://github.com/decred/politeia/pull/279
-1050,2,1,sndurkin,2018-05-10 18:06:41,https://github.com/decred/politeia/issues/278
-1051,2,1,sndurkin,2018-05-10 15:33:57,https://github.com/decred/politeia/pull/277
-1052,2,1,fernandoabolafio,2018-05-10 14:04:17,https://github.com/decred/politeia/issues/276
-1053,2,1,fernandoabolafio,2018-05-10 13:35:13,https://github.com/decred/politeia/pull/275
-1054,2,1,fernandoabolafio,2018-05-09 20:11:37,https://github.com/decred/politeia/pull/274
-1055,2,1,EvertonMelo,2018-05-08 13:36:23,https://github.com/decred/politeia/pull/273
-1056,2,1,EvertonMelo,2018-05-08 13:31:34,https://github.com/decred/politeia/pull/272
-1057,2,1,fernandoabolafio,2018-05-07 18:02:05,https://github.com/decred/politeia/pull/271
-1058,2,1,fernandoabolafio,2018-05-07 16:20:54,https://github.com/decred/politeia/issues/270
-1059,2,1,fernandoabolafio,2018-05-07 14:03:26,https://github.com/decred/politeia/pull/269
-1060,2,1,fernandoabolafio,2018-05-07 13:58:00,https://github.com/decred/politeia/issues/268
-1061,2,1,lukebp,2018-05-03 04:43:52,https://github.com/decred/politeia/pull/267
-1062,2,1,RichardRed0x,2018-05-01 14:43:24,https://github.com/decred/politeia/issues/266
-1063,2,1,marcopeereboom,2018-04-30 13:53:45,https://github.com/decred/politeia/issues/265
-1064,2,1,marcopeereboom,2018-04-30 13:49:42,https://github.com/decred/politeia/issues/264
-1065,2,1,marcopeereboom,2018-04-30 13:47:30,https://github.com/decred/politeia/issues/263
-1066,2,1,marcopeereboom,2018-04-30 13:45:49,https://github.com/decred/politeia/issues/262
-1067,2,1,lukebp,2018-04-30 03:08:19,https://github.com/decred/politeia/issues/261
-1068,2,1,marcopeereboom,2018-04-20 17:51:16,https://github.com/decred/politeia/pull/260
-1069,2,1,marcopeereboom,2018-04-19 22:01:11,https://github.com/decred/politeia/issues/259
-1070,2,1,dajohi,2018-04-19 15:13:51,https://github.com/decred/politeia/pull/258
-1071,2,1,dajohi,2018-04-19 14:57:42,https://github.com/decred/politeia/pull/257
-1072,2,1,vctt94,2018-04-18 13:42:59,https://github.com/decred/politeia/pull/256
-1073,2,1,dajohi,2018-04-17 18:14:33,https://github.com/decred/politeia/pull/255
-1074,2,1,marcopeereboom,2018-04-17 16:04:47,https://github.com/decred/politeia/pull/254
-1075,2,1,marcopeereboom,2018-04-17 15:41:56,https://github.com/decred/politeia/pull/253
-1076,2,1,marcopeereboom,2018-04-17 15:03:32,https://github.com/decred/politeia/issues/252
-1077,2,1,marcopeereboom,2018-04-17 13:30:02,https://github.com/decred/politeia/pull/251
-1078,2,1,marcopeereboom,2018-04-16 20:22:09,https://github.com/decred/politeia/pull/250
-1079,2,1,marcopeereboom,2018-04-16 19:40:35,https://github.com/decred/politeia/pull/249
-1080,2,1,marcopeereboom,2018-04-16 16:52:32,https://github.com/decred/politeia/pull/248
-1081,2,1,dajohi,2018-04-12 18:39:54,https://github.com/decred/politeia/pull/247
-1082,2,1,vctt94,2018-04-12 18:26:32,https://github.com/decred/politeia/pull/246
-1083,2,1,dajohi,2018-04-11 15:54:52,https://github.com/decred/politeia/pull/245
-1084,2,1,marcopeereboom,2018-04-11 14:57:37,https://github.com/decred/politeia/pull/244
-1085,2,1,dajohi,2018-04-10 19:37:51,https://github.com/decred/politeia/pull/243
-1086,2,1,marcopeereboom,2018-04-09 14:27:05,https://github.com/decred/politeia/pull/242
-1087,2,1,vctt94,2018-03-29 20:48:22,https://github.com/decred/politeia/pull/241
-1088,2,1,dajohi,2018-03-29 17:17:12,https://github.com/decred/politeia/pull/240
-1089,2,1,dajohi,2018-03-29 17:00:51,https://github.com/decred/politeia/pull/239
-1090,2,1,sndurkin,2018-03-28 21:12:55,https://github.com/decred/politeia/pull/238
-1091,2,1,vctt94,2018-03-22 15:40:54,https://github.com/decred/politeia/issues/237
-1092,2,1,marcopeereboom,2018-03-13 14:52:36,https://github.com/decred/politeia/pull/236
-1093,2,1,sndurkin,2018-02-27 05:06:09,https://github.com/decred/politeia/pull/235
-1094,2,1,sudoscript,2018-02-26 00:41:46,https://github.com/decred/politeia/pull/234
-1095,2,1,sndurkin,2018-02-22 15:45:52,https://github.com/decred/politeia/issues/233
-1096,2,1,sndurkin,2018-02-22 06:10:22,https://github.com/decred/politeia/pull/232
-1097,2,1,sndurkin,2018-02-21 16:53:41,https://github.com/decred/politeia/pull/231
-1098,2,1,sndurkin,2018-02-21 16:45:28,https://github.com/decred/politeia/pull/230
-1099,2,1,vctt94,2018-02-21 15:50:31,https://github.com/decred/politeia/pull/229
-1100,2,1,dajohi,2018-02-15 18:36:24,https://github.com/decred/politeia/pull/228
-1101,2,1,sndurkin,2018-02-15 16:27:00,https://github.com/decred/politeia/pull/227
-1102,2,1,sndurkin,2018-02-13 14:57:34,https://github.com/decred/politeia/pull/226
-1103,2,1,AlanL1,2018-02-12 08:49:53,https://github.com/decred/politeia/issues/225
-1104,2,1,sndurkin,2018-02-06 03:58:28,https://github.com/decred/politeia/pull/224
-1105,2,1,fernandoabolafio,2018-02-05 01:30:16,https://github.com/decred/politeia/issues/223
-1106,2,1,AlanL1,2018-01-31 11:03:14,https://github.com/decred/politeia/pull/222
-1107,2,1,AlanL1,2018-01-30 16:32:27,https://github.com/decred/politeia/pull/221
-1108,2,1,tiagoalvesdulce,2018-01-30 13:40:53,https://github.com/decred/politeia/issues/220
-1109,2,1,sndurkin,2018-01-23 05:45:53,https://github.com/decred/politeia/pull/219
-1110,2,1,jolan,2018-01-22 15:00:18,https://github.com/decred/politeia/issues/218
-1111,2,1,sndurkin,2018-01-21 06:26:34,https://github.com/decred/politeia/issues/217
-1112,2,1,sndurkin,2018-01-21 05:51:33,https://github.com/decred/politeia/pull/216
-1113,2,1,fernandoabolafio,2018-01-20 14:21:56,https://github.com/decred/politeia/pull/215
-1114,2,1,fernandoabolafio,2018-01-18 16:26:07,https://github.com/decred/politeia/pull/214
-1115,2,1,sndurkin,2018-01-16 17:10:42,https://github.com/decred/politeia/issues/213
-1116,2,1,marcopeereboom,2018-01-16 16:28:59,https://github.com/decred/politeia/pull/212
-1117,2,1,sndurkin,2018-01-16 03:05:01,https://github.com/decred/politeia/issues/211
-1118,2,1,brunobraga95,2018-01-16 02:28:05,https://github.com/decred/politeia/issues/210
-1119,2,1,vctt94,2018-01-15 18:10:19,https://github.com/decred/politeia/issues/209
-1120,2,1,sndurkin,2018-01-15 17:41:02,https://github.com/decred/politeia/issues/208
-1121,2,1,sndurkin,2018-01-15 15:49:53,https://github.com/decred/politeia/issues/207
-1122,2,1,AlanL1,2018-01-15 08:52:40,https://github.com/decred/politeia/pull/206
-1123,2,1,sndurkin,2018-01-14 05:55:50,https://github.com/decred/politeia/pull/205
-1124,2,1,sndurkin,2018-01-14 03:13:23,https://github.com/decred/politeia/pull/204
-1125,2,1,sndurkin,2018-01-13 20:36:36,https://github.com/decred/politeia/pull/203
-1126,2,1,sndurkin,2018-01-12 00:02:17,https://github.com/decred/politeia/pull/202
-1127,2,1,sndurkin,2018-01-11 15:12:49,https://github.com/decred/politeia/issues/201
-1128,2,1,sndurkin,2018-01-11 14:53:57,https://github.com/decred/politeia/pull/200
-1129,2,1,sndurkin,2018-01-08 19:44:15,https://github.com/decred/politeia/issues/199
-1130,2,1,vctt94,2018-01-08 17:36:20,https://github.com/decred/politeia/pull/198
-1131,2,1,sndurkin,2018-01-08 16:31:54,https://github.com/decred/politeia/issues/197
-1132,2,1,sndurkin,2017-12-31 07:15:38,https://github.com/decred/politeia/pull/196
-1133,2,1,sndurkin,2017-12-30 21:30:07,https://github.com/decred/politeia/pull/195
-1134,2,1,fernandoabolafio,2017-12-26 16:23:24,https://github.com/decred/politeia/issues/194
-1135,2,1,dajohi,2017-12-15 20:43:07,https://github.com/decred/politeia/issues/193
-1136,2,1,marcopeereboom,2017-12-15 20:19:54,https://github.com/decred/politeia/pull/192
-1137,2,1,jolan,2017-12-15 19:37:16,https://github.com/decred/politeia/pull/191
-1138,2,1,marcopeereboom,2017-12-15 19:15:23,https://github.com/decred/politeia/pull/190
-1139,2,1,jolan,2017-12-12 23:00:00,https://github.com/decred/politeia/pull/189
-1140,2,1,sndurkin,2017-12-12 21:50:27,https://github.com/decred/politeia/issues/188
-1141,2,1,marcopeereboom,2017-12-07 20:29:37,https://github.com/decred/politeia/pull/187
-1142,2,1,sndurkin,2017-12-07 15:08:31,https://github.com/decred/politeia/issues/186
-1143,2,1,marcopeereboom,2017-12-04 19:55:33,https://github.com/decred/politeia/issues/185
-1144,2,1,marcopeereboom,2017-12-04 19:45:07,https://github.com/decred/politeia/issues/184
-1145,2,1,marcopeereboom,2017-12-04 17:30:52,https://github.com/decred/politeia/pull/183
-1146,2,1,marcopeereboom,2017-12-04 15:03:51,https://github.com/decred/politeia/pull/182
-1147,2,1,vctt94,2017-12-04 13:38:20,https://github.com/decred/politeia/pull/181
-1148,2,1,rgeraldes,2017-12-03 20:46:17,https://github.com/decred/politeia/issues/180
-1149,2,1,rgeraldes,2017-12-03 00:23:08,https://github.com/decred/politeia/issues/179
-1150,2,1,dajohi,2017-12-01 19:18:13,https://github.com/decred/politeia/pull/178
-1151,2,1,rgeraldes,2017-12-01 19:02:38,https://github.com/decred/politeia/issues/177
-1152,2,1,marcopeereboom,2017-12-01 18:58:48,https://github.com/decred/politeia/pull/176
-1153,2,1,dajohi,2017-12-01 18:57:51,https://github.com/decred/politeia/pull/175
-1154,2,1,marcopeereboom,2017-12-01 18:38:30,https://github.com/decred/politeia/pull/174
-1155,2,1,marcopeereboom,2017-12-01 03:54:06,https://github.com/decred/politeia/pull/173
-1156,2,1,sndurkin,2017-12-01 03:48:31,https://github.com/decred/politeia/pull/172
-1157,2,1,sndurkin,2017-12-01 03:23:20,https://github.com/decred/politeia/pull/171
-1158,2,1,sndurkin,2017-12-01 03:19:36,https://github.com/decred/politeia/pull/170
-1159,2,1,sndurkin,2017-12-01 02:09:13,https://github.com/decred/politeia/issues/169
-1160,2,1,sndurkin,2017-12-01 00:09:58,https://github.com/decred/politeia/issues/168
-1161,2,1,marcopeereboom,2017-11-30 15:22:57,https://github.com/decred/politeia/issues/167
-1162,2,1,marcopeereboom,2017-11-30 15:12:27,https://github.com/decred/politeia/issues/166
-1163,2,1,marcopeereboom,2017-11-30 13:31:06,https://github.com/decred/politeia/pull/165
-1164,2,1,sndurkin,2017-11-30 03:09:59,https://github.com/decred/politeia/pull/164
-1165,2,1,sndurkin,2017-11-29 19:02:25,https://github.com/decred/politeia/pull/163
-1166,2,1,oktapodia,2017-11-29 16:11:52,https://github.com/decred/politeia/issues/162
-1167,2,1,oktapodia,2017-11-29 16:10:25,https://github.com/decred/politeia/issues/161
-1168,2,1,rgeraldes,2017-11-28 23:29:02,https://github.com/decred/politeia/pull/160
-1169,2,1,marcopeereboom,2017-11-27 15:34:20,https://github.com/decred/politeia/pull/159
-1170,2,1,jolan,2017-11-22 19:13:46,https://github.com/decred/politeia/pull/158
-1171,2,1,jolan,2017-11-22 18:30:08,https://github.com/decred/politeia/pull/157
-1172,2,1,rgeraldes,2017-11-20 15:47:32,https://github.com/decred/politeia/pull/156
-1173,2,1,rgeraldes,2017-11-20 15:14:10,https://github.com/decred/politeia/issues/155
-1174,2,1,marcopeereboom,2017-11-20 15:02:18,https://github.com/decred/politeia/pull/154
-1175,2,1,JFixby,2017-11-20 14:30:16,https://github.com/decred/politeia/issues/153
-1176,2,1,jolan,2017-11-17 16:19:04,https://github.com/decred/politeia/pull/152
-1177,2,1,rgeraldes,2017-11-16 21:09:36,https://github.com/decred/politeia/pull/151
-1178,2,1,vctt94,2017-11-16 19:05:58,https://github.com/decred/politeia/issues/150
-1179,2,1,vctt94,2017-11-16 18:50:37,https://github.com/decred/politeia/pull/149
-1180,2,1,marcopeereboom,2017-11-16 17:03:07,https://github.com/decred/politeia/issues/148
-1181,2,1,sndurkin,2017-11-16 16:59:26,https://github.com/decred/politeia/issues/147
-1182,2,1,go1dfish,2017-11-16 15:58:26,https://github.com/decred/politeia/issues/146
-1183,2,1,rgeraldes,2017-11-16 02:48:10,https://github.com/decred/politeia/issues/145
-1184,2,1,rgeraldes,2017-11-15 23:31:28,https://github.com/decred/politeia/pull/144
-1185,2,1,marcopeereboom,2017-11-14 20:13:10,https://github.com/decred/politeia/pull/143
-1186,2,1,sndurkin,2017-11-14 17:11:49,https://github.com/decred/politeia/pull/142
-1187,2,1,webmasterraj,2017-11-14 03:06:33,https://github.com/decred/politeia/pull/141
-1188,2,1,marcopeereboom,2017-11-13 14:45:00,https://github.com/decred/politeia/pull/140
-1189,2,1,sndurkin,2017-11-13 04:57:38,https://github.com/decred/politeia/pull/139
-1190,2,1,sudoscript,2017-11-13 04:28:53,https://github.com/decred/politeia/pull/138
-1191,2,1,sndurkin,2017-11-13 03:25:10,https://github.com/decred/politeia/pull/137
-1192,2,1,sndurkin,2017-11-13 02:22:22,https://github.com/decred/politeia/pull/136
-1193,2,1,sndurkin,2017-11-10 23:07:22,https://github.com/decred/politeia/issues/135
-1194,2,1,rgeraldes,2017-11-10 04:03:53,https://github.com/decred/politeia/pull/134
-1195,2,1,rgeraldes,2017-11-09 22:28:22,https://github.com/decred/politeia/pull/133
-1196,2,1,marcopeereboom,2017-11-09 18:37:45,https://github.com/decred/politeia/issues/132
-1197,2,1,marcopeereboom,2017-11-09 16:02:15,https://github.com/decred/politeia/pull/131
-1198,2,1,sndurkin,2017-11-09 15:14:49,https://github.com/decred/politeia/pull/130
-1199,2,1,sndurkin,2017-11-08 21:29:10,https://github.com/decred/politeia/issues/129
-1200,2,1,sndurkin,2017-11-08 20:19:40,https://github.com/decred/politeia/issues/128
-1201,2,1,vctt94,2017-11-07 18:43:27,https://github.com/decred/politeia/pull/127
-1202,2,1,rgeraldes,2017-11-07 16:35:16,https://github.com/decred/politeia/pull/126
-1203,2,1,jolan,2017-11-07 16:21:51,https://github.com/decred/politeia/issues/125
-1204,2,1,jolan,2017-11-07 16:20:27,https://github.com/decred/politeia/issues/124
-1205,2,1,jolan,2017-11-07 16:15:05,https://github.com/decred/politeia/issues/123
-1206,2,1,sndurkin,2017-11-07 05:04:09,https://github.com/decred/politeia/issues/122
-1207,2,1,sndurkin,2017-11-07 04:06:49,https://github.com/decred/politeia/issues/121
-1208,2,1,rgeraldes,2017-11-07 00:28:37,https://github.com/decred/politeia/pull/120
-1209,2,1,rgeraldes,2017-11-06 22:48:48,https://github.com/decred/politeia/pull/119
-1210,2,1,sndurkin,2017-11-06 18:25:43,https://github.com/decred/politeia/issues/118
-1211,2,1,sndurkin,2017-11-05 18:23:43,https://github.com/decred/politeia/pull/117
-1212,2,1,sndurkin,2017-11-05 05:09:15,https://github.com/decred/politeia/pull/116
-1213,2,1,sndurkin,2017-11-03 19:06:29,https://github.com/decred/politeia/issues/115
-1214,2,1,sndurkin,2017-11-03 14:37:24,https://github.com/decred/politeia/issues/114
-1215,2,1,rgeraldes,2017-11-03 04:11:06,https://github.com/decred/politeia/pull/113
-1216,2,1,rgeraldes,2017-11-02 22:21:41,https://github.com/decred/politeia/pull/112
-1217,2,1,sndurkin,2017-11-02 17:16:13,https://github.com/decred/politeia/issues/111
-1218,2,1,sndurkin,2017-11-02 16:07:58,https://github.com/decred/politeia/issues/110
-1219,2,1,sndurkin,2017-11-02 16:07:03,https://github.com/decred/politeia/issues/109
-1220,2,1,sndurkin,2017-11-02 15:18:13,https://github.com/decred/politeia/pull/108
-1221,2,1,marcopeereboom,2017-11-02 12:39:24,https://github.com/decred/politeia/issues/107
-1222,2,1,marcopeereboom,2017-10-31 16:03:09,https://github.com/decred/politeia/pull/106
-1223,2,1,sndurkin,2017-10-30 14:09:51,https://github.com/decred/politeia/pull/105
-1224,2,1,sndurkin,2017-10-30 02:59:34,https://github.com/decred/politeia/pull/104
-1225,2,1,sndurkin,2017-10-28 14:34:15,https://github.com/decred/politeia/pull/103
-1226,2,1,sndurkin,2017-10-27 22:15:55,https://github.com/decred/politeia/issues/102
-1227,2,1,sndurkin,2017-10-27 17:18:15,https://github.com/decred/politeia/issues/101
-1228,2,1,sndurkin,2017-10-27 14:05:26,https://github.com/decred/politeia/issues/100
-1229,2,1,sndurkin,2017-10-27 13:33:12,https://github.com/decred/politeia/issues/99
-1230,2,1,sndurkin,2017-10-26 14:23:10,https://github.com/decred/politeia/pull/98
-1231,2,1,sndurkin,2017-10-25 21:09:24,https://github.com/decred/politeia/issues/97
-1232,2,1,sndurkin,2017-10-25 19:12:02,https://github.com/decred/politeia/issues/96
-1233,2,1,sndurkin,2017-10-25 19:09:17,https://github.com/decred/politeia/issues/95
-1234,2,1,marcopeereboom,2017-10-25 16:26:33,https://github.com/decred/politeia/pull/94
-1235,2,1,dajohi,2017-10-25 14:58:44,https://github.com/decred/politeia/pull/93
-1236,2,1,marcopeereboom,2017-10-24 21:51:26,https://github.com/decred/politeia/pull/92
-1237,2,1,sndurkin,2017-10-24 17:04:48,https://github.com/decred/politeia/pull/91
-1238,2,1,dajohi,2017-10-24 14:34:21,https://github.com/decred/politeia/issues/90
-1239,2,1,sndurkin,2017-10-23 17:56:02,https://github.com/decred/politeia/pull/89
-1240,2,1,sndurkin,2017-10-22 03:56:11,https://github.com/decred/politeia/pull/88
-1241,2,1,sndurkin,2017-10-20 21:03:01,https://github.com/decred/politeia/issues/87
-1242,2,1,dajohi,2017-10-20 18:49:44,https://github.com/decred/politeia/issues/86
-1243,2,1,sndurkin,2017-10-20 18:25:55,https://github.com/decred/politeia/pull/85
-1244,2,1,sndurkin,2017-10-20 15:09:12,https://github.com/decred/politeia/pull/84
-1245,2,1,sndurkin,2017-10-20 13:46:37,https://github.com/decred/politeia/issues/83
-1246,2,1,marcopeereboom,2017-10-19 20:35:08,https://github.com/decred/politeia/pull/82
-1247,2,1,marcopeereboom,2017-10-19 18:24:40,https://github.com/decred/politeia/pull/81
-1248,2,1,dajohi,2017-10-19 17:41:44,https://github.com/decred/politeia/pull/80
-1249,2,1,sndurkin,2017-10-19 16:49:47,https://github.com/decred/politeia/issues/79
-1250,2,1,dajohi,2017-10-19 15:10:48,https://github.com/decred/politeia/issues/78
-1251,2,1,sndurkin,2017-10-19 14:58:06,https://github.com/decred/politeia/pull/77
-1252,2,1,sndurkin,2017-10-18 22:10:06,https://github.com/decred/politeia/issues/76
-1253,2,1,sndurkin,2017-10-18 20:57:05,https://github.com/decred/politeia/issues/75
-1254,2,1,marcopeereboom,2017-10-18 19:41:50,https://github.com/decred/politeia/pull/74
-1255,2,1,marcopeereboom,2017-10-18 16:50:41,https://github.com/decred/politeia/issues/73
-1256,2,1,dajohi,2017-10-18 15:54:16,https://github.com/decred/politeia/pull/72
-1257,2,1,oktapodia,2017-10-18 14:23:50,https://github.com/decred/politeia/pull/71
-1258,2,1,go1dfish,2017-10-18 14:17:53,https://github.com/decred/politeia/pull/70
-1259,2,1,sndurkin,2017-10-18 13:58:47,https://github.com/decred/politeia/pull/69
-1260,2,1,marcopeereboom,2017-10-18 13:52:27,https://github.com/decred/politeia/pull/68
-1261,2,1,sndurkin,2017-10-18 13:26:23,https://github.com/decred/politeia/pull/67
-1262,2,1,sndurkin,2017-10-18 03:39:55,https://github.com/decred/politeia/pull/66
-1263,2,1,sndurkin,2017-10-18 03:11:35,https://github.com/decred/politeia/issues/65
-1264,2,1,dajohi,2017-10-17 22:09:59,https://github.com/decred/politeia/pull/64
-1265,2,1,sndurkin,2017-10-17 22:01:09,https://github.com/decred/politeia/issues/63
-1266,2,1,sndurkin,2017-10-17 16:35:29,https://github.com/decred/politeia/pull/62
-1267,2,1,dajohi,2017-10-17 16:26:29,https://github.com/decred/politeia/pull/61
-1268,2,1,sndurkin,2017-10-17 15:10:58,https://github.com/decred/politeia/pull/60
-1269,2,1,sndurkin,2017-10-16 21:20:27,https://github.com/decred/politeia/issues/59
-1270,2,1,sndurkin,2017-10-16 20:39:24,https://github.com/decred/politeia/issues/58
-1271,2,1,dajohi,2017-10-16 19:48:19,https://github.com/decred/politeia/pull/57
-1272,2,1,dajohi,2017-10-16 19:23:32,https://github.com/decred/politeia/pull/56
-1273,2,1,dajohi,2017-10-16 19:01:51,https://github.com/decred/politeia/issues/55
-1274,2,1,sndurkin,2017-10-16 13:23:56,https://github.com/decred/politeia/pull/54
-1275,2,1,marcopeereboom,2017-10-11 13:19:32,https://github.com/decred/politeia/pull/53
-1276,2,1,sndurkin,2017-10-05 18:38:14,https://github.com/decred/politeia/issues/52
-1277,2,1,sndurkin,2017-10-05 18:34:32,https://github.com/decred/politeia/issues/51
-1278,2,1,dajohi,2017-10-05 18:01:22,https://github.com/decred/politeia/pull/50
-1279,2,1,marcopeereboom,2017-10-05 13:07:59,https://github.com/decred/politeia/pull/49
-1280,2,1,go1dfish,2017-10-04 16:38:38,https://github.com/decred/politeia/issues/48
-1281,2,1,sndurkin,2017-10-04 04:36:00,https://github.com/decred/politeia/pull/47
-1282,2,1,marcopeereboom,2017-10-03 18:57:07,https://github.com/decred/politeia/issues/46
-1283,2,1,sndurkin,2017-10-01 03:00:23,https://github.com/decred/politeia/pull/45
-1284,2,1,sndurkin,2017-09-29 16:44:26,https://github.com/decred/politeia/pull/44
-1285,2,1,sndurkin,2017-09-29 16:40:46,https://github.com/decred/politeia/issues/43
-1286,2,1,sndurkin,2017-09-29 16:38:36,https://github.com/decred/politeia/issues/42
-1287,2,1,sndurkin,2017-09-29 16:23:08,https://github.com/decred/politeia/issues/41
-1288,2,1,marcopeereboom,2017-09-29 16:19:54,https://github.com/decred/politeia/issues/40
-1289,2,1,go1dfish,2017-09-29 15:12:12,https://github.com/decred/politeia/issues/39
-1290,2,1,sndurkin,2017-09-28 02:51:21,https://github.com/decred/politeia/pull/38
-1291,2,1,dajohi,2017-09-27 20:01:51,https://github.com/decred/politeia/pull/37
-1292,2,1,sndurkin,2017-09-26 15:27:23,https://github.com/decred/politeia/pull/36
-1293,2,1,marcopeereboom,2017-09-21 15:50:58,https://github.com/decred/politeia/pull/35
-1294,2,1,sndurkin,2017-09-21 14:56:02,https://github.com/decred/politeia/pull/34
-1295,2,1,sndurkin,2017-09-21 02:36:22,https://github.com/decred/politeia/pull/33
-1296,2,1,marcopeereboom,2017-09-19 19:02:30,https://github.com/decred/politeia/pull/32
-1297,2,1,marcopeereboom,2017-09-19 13:59:35,https://github.com/decred/politeia/issues/31
-1298,2,1,marcopeereboom,2017-09-19 13:57:25,https://github.com/decred/politeia/issues/30
-1299,2,1,marcopeereboom,2017-09-19 13:55:30,https://github.com/decred/politeia/issues/29
-1300,2,1,marcopeereboom,2017-09-19 13:53:14,https://github.com/decred/politeia/issues/28
-1301,2,1,marcopeereboom,2017-09-19 13:51:01,https://github.com/decred/politeia/issues/27
-1302,2,1,marcopeereboom,2017-09-19 13:46:56,https://github.com/decred/politeia/issues/26
-1303,2,1,marcopeereboom,2017-09-18 15:55:28,https://github.com/decred/politeia/pull/25
-1304,2,1,sndurkin,2017-09-16 17:30:24,https://github.com/decred/politeia/pull/24
-1305,2,1,marcopeereboom,2017-09-15 16:03:06,https://github.com/decred/politeia/pull/23
-1306,2,1,sndurkin,2017-09-15 00:24:05,https://github.com/decred/politeia/pull/22
-1307,2,1,marcopeereboom,2017-09-14 19:27:51,https://github.com/decred/politeia/pull/21
-1308,2,1,marcopeereboom,2017-09-14 19:06:28,https://github.com/decred/politeia/pull/20
-1309,2,1,sndurkin,2017-09-14 15:23:31,https://github.com/decred/politeia/pull/19
-1310,2,1,marcopeereboom,2017-09-14 01:43:48,https://github.com/decred/politeia/issues/18
-1311,2,1,marcopeereboom,2017-09-13 21:59:30,https://github.com/decred/politeia/pull/17
-1312,2,1,marcopeereboom,2017-09-13 21:10:32,https://github.com/decred/politeia/pull/16
-1313,2,1,marcopeereboom,2017-09-13 21:10:14,https://github.com/decred/politeia/pull/15
-1314,2,1,marcopeereboom,2017-09-13 15:32:08,https://github.com/decred/politeia/issues/14
-1315,2,1,marcopeereboom,2017-09-13 15:23:52,https://github.com/decred/politeia/issues/13
-1316,2,1,sndurkin,2017-09-13 02:19:56,https://github.com/decred/politeia/pull/12
-1317,2,1,marcopeereboom,2017-09-12 22:07:48,https://github.com/decred/politeia/issues/11
-1318,2,1,marcopeereboom,2017-09-12 19:54:11,https://github.com/decred/politeia/pull/10
-1319,2,1,sndurkin,2017-09-12 13:14:18,https://github.com/decred/politeia/pull/9
-1320,2,1,marcopeereboom,2017-09-08 14:27:01,https://github.com/decred/politeia/pull/8
-1321,2,1,sndurkin,2017-09-07 14:27:33,https://github.com/decred/politeia/pull/7
-1322,2,1,marcopeereboom,2017-09-01 15:58:16,https://github.com/decred/politeia/pull/6
-1323,2,1,dajohi,2017-08-29 18:04:31,https://github.com/decred/politeia/issues/5
-1324,2,1,sndurkin,2017-08-29 13:27:46,https://github.com/decred/politeia/pull/4
-1325,2,1,marcopeereboom,2017-08-29 13:18:03,https://github.com/decred/politeia/pull/3
-1326,2,1,sndurkin,2017-08-25 04:49:45,https://github.com/decred/politeia/issues/2
-1327,2,1,sndurkin,2017-08-25 04:32:04,https://github.com/decred/politeia/pull/1
+1,1,1,David Hill,2019-03-29 17:03:52,https://github.com/decred/politeia/commit/13eb0038975ff4fcddb70565687434354d208a0f
+2,1,1,Alex Yocom-Piatt,2019-03-27 21:57:33,https://github.com/decred/politeia/commit/44671c42055f20b2a88cd25ec9c89a05f3930156
+3,1,1,Jonathan Chappelow,2019-03-26 22:24:09,https://github.com/decred/politeia/commit/95f8c103604d2ba35c9146f692d99960e6dd2d03
+4,1,1,Jonathan Chappelow,2019-03-25 18:15:17,https://github.com/decred/politeia/commit/2f2e295e783340507acc704ca3c2ffe876ad2572
+5,1,1,Alex Yocom-Piatt,2019-03-25 16:59:47,https://github.com/decred/politeia/commit/d1ec6ce2a5ab291545ef08cb2b6a38bea41fb147
+6,1,1,David Hill,2019-03-25 15:37:31,https://github.com/decred/politeia/commit/bb7e7c7b69531526cbeffcdb455dc196bb64eae0
+7,1,1,lukebp,2019-03-25 14:46:23,https://github.com/decred/politeia/commit/a813df433dab42cc62753793310b4357311e2cad
+8,1,1,lukebp,2019-03-25 14:43:34,https://github.com/decred/politeia/commit/993f3a22b9fe14c257f514d7c4b84f18d1f642a2
+9,1,1,lukebp,2019-03-25 14:40:21,https://github.com/decred/politeia/commit/f06c0bef6f8f3d35d07180586e27e1d1665384fe
+10,1,1,Josh Rickmar,2019-03-25 13:52:10,https://github.com/decred/politeia/commit/6d7b23a66d77739caf34bbecde054e5bdf0bb856
+11,1,1,David Hill,2019-03-22 16:50:48,https://github.com/decred/politeia/commit/dda90803592a2a5f19f0f3216e7c9d265ea08392
+12,1,1,David Hill,2019-03-22 16:50:23,https://github.com/decred/politeia/commit/e2e42499077454bc460d8451f20257acfcc876d2
+13,1,1,David Hill,2019-03-22 16:50:09,https://github.com/decred/politeia/commit/c0c858a317350312c5f7212bf7d0b6ecee716f94
+14,1,1,lukebp,2019-03-21 17:54:40,https://github.com/decred/politeia/commit/a9feb4a6aa072fdea389b897d88554ea3bc208ec
+15,1,1,Alex Yocom-Piatt,2019-03-20 15:02:47,https://github.com/decred/politeia/commit/8cc3feb17528ee831553875125bc9777e0161fc0
+16,1,1,lukebp,2019-03-19 21:07:08,https://github.com/decred/politeia/commit/291c41a4978bcc486467179a93939ce5d229f8ac
+17,1,1,lukebp,2019-03-19 18:19:13,https://github.com/decred/politeia/commit/a56d3c29b11a41f13fede453009d46457bae73fb
+18,1,1,lukebp,2019-03-18 18:08:37,https://github.com/decred/politeia/commit/bc0d0056ef578f24f718611cddf101f3b155dec1
+19,1,1,Seth Benton,2019-03-15 20:38:03,https://github.com/decred/politeia/commit/dc4a85ee43c3ffc6aa231cc235a1dfbd5ddf0c9b
+20,1,1,lukebp,2019-03-15 18:12:49,https://github.com/decred/politeia/commit/ff6f86e355b0b68a6f7ad7409bbf11e7130cec79
+21,1,1,Marco Peereboom,2019-03-14 16:19:24,https://github.com/decred/politeia/commit/fb746809ca0556babaf0b17566c01535eef6a364
+22,1,1,Marco Peereboom,2019-03-13 15:09:09,https://github.com/decred/politeia/commit/d119539c966630dde66b100f3a97e8b1ab9841a6
+23,1,1,Marco Peereboom,2019-03-11 19:23:59,https://github.com/decred/politeia/commit/0b5657115303e1453012e30331de2f3318571702
+24,1,1,lukebp,2019-03-11 16:27:18,https://github.com/decred/politeia/commit/c80ca372c920403f38f1f8b0575809241df2bcdf
+25,1,1,Fernando Abolafio,2019-03-11 13:45:25,https://github.com/decred/politeia/commit/0cff3c3afdff7d94b86ef8ef8e3e22f35507b8f7
+26,1,1,Marco Peereboom,2019-03-06 20:47:34,https://github.com/decred/politeia/commit/00994d0941c482ebadfbffbceef00706dbc9dc08
+27,1,1,Dave Collins,2019-03-04 17:41:12,https://github.com/decred/politeia/commit/e61308e677441afdfbe71c192704c94cc4c88880
+28,1,1,Alex Yocom-Piatt,2019-03-04 16:56:33,https://github.com/decred/politeia/commit/7d0485ab08b5883ad16a7e1a6f70ba32e4270fa4
+29,1,1,lukebp,2019-02-26 17:01:33,https://github.com/decred/politeia/commit/8057ced5e4c0a04823a261cc064602f1a8a2ab1b
+30,1,1,Seth Benton,2019-02-26 12:32:41,https://github.com/decred/politeia/commit/ec4698af3c7b7e3b5d149574c6a86f7cc8889233
+31,1,1,lukebp,2019-02-25 16:08:55,https://github.com/decred/politeia/commit/769633bc71a9eb4c51c315b1362080489d9489cf
+32,1,1,lukebp,2019-02-15 17:59:39,https://github.com/decred/politeia/commit/73ba15aa6d3e8ba590f5cf5fc1120938997283d6
+33,1,1,lukebp,2019-02-14 20:53:47,https://github.com/decred/politeia/commit/dbf0dd26240dd13beb130d1d7c03b75d2ea71bb6
+34,1,1,lukebp,2019-02-14 13:49:19,https://github.com/decred/politeia/commit/bf7d8977cba9fea583a0801128c6af3e4d2348bd
+35,1,1,David Hill,2019-02-11 18:25:47,https://github.com/decred/politeia/commit/63dbf2f0bc556aed0d5acd6815e5f63d3797b1a1
+36,1,1,Thiago de Freitas Figueiredo,2019-02-11 18:08:05,https://github.com/decred/politeia/commit/90bcf5006ec1bf049d26ef0fb8b7f57bdc4026c9
+37,1,1,lukebp,2019-02-11 18:07:35,https://github.com/decred/politeia/commit/24488f93b3511cdeb80c40c157999a72d580c4e6
+38,1,1,David Hill,2019-02-11 16:41:20,https://github.com/decred/politeia/commit/c3bdf807c67385483a882ad349736d707f0f51cf
+39,1,1,David Hill,2019-02-11 15:44:11,https://github.com/decred/politeia/commit/773eafa66db29e7490f963cafa12b5d0de3b1523
+40,1,1,lukebp,2019-02-08 21:03:34,https://github.com/decred/politeia/commit/076c4f894ea1909bcd009ac802f452ca342b685c
+41,1,1,Seth Benton,2019-02-01 16:45:27,https://github.com/decred/politeia/commit/f2a7885d409311dc59c3d63722a510a9875b14bd
+42,1,1,Seth Benton,2019-02-01 16:44:03,https://github.com/decred/politeia/commit/3cbf2f1b731518c17104d16ac87b828c53abd1e1
+43,1,1,Seth Benton,2019-01-28 11:13:11,https://github.com/decred/politeia/commit/052a120f7e377e43e2869274e0660725458d37a9
+44,1,1,David Hill,2019-01-24 20:01:41,https://github.com/decred/politeia/commit/7fdf5bda526af42955d4b970300c338230a28cb4
+45,1,1,Marco Peereboom,2019-01-16 20:00:39,https://github.com/decred/politeia/commit/268d6c8bbba90292b923188f6a82bcbe636d6ee1
+46,1,1,orthomind,2019-01-14 03:33:29,https://github.com/decred/politeia/commit/793ab1b7b1e95f7d625b3e0daf4e3587fecd1d67
+47,1,1,Everton Melo,2019-01-04 21:52:05,https://github.com/decred/politeia/commit/8cdcda2aef9d9d1ba3ccad9d7d4891e382444001
+48,1,1,David Hill,2019-01-02 15:31:41,https://github.com/decred/politeia/commit/3b7271edd42beab70a2be4db19bd6e4abe0a6368
+49,1,1,Thiago de Freitas Figueiredo,2018-12-31 12:17:44,https://github.com/decred/politeia/commit/a56b26227c08ec70eb78ee3879812a5b856c38c6
+50,1,1,lukebp,2018-12-20 16:29:08,https://github.com/decred/politeia/commit/8624e18eb9e678a9a1642fb4f51fa425def6775a
+51,1,1,lukebp,2018-12-20 16:28:44,https://github.com/decred/politeia/commit/5bfb21ffba6c5f06866f74cb0e48e129ede19dc6
+52,1,1,David Hill,2018-12-18 16:34:26,https://github.com/decred/politeia/commit/2eeea9db91b6d69d5818ddf5cdb0253db48bd072
+53,1,1,David Hill,2018-12-18 15:21:41,https://github.com/decred/politeia/commit/8afafff882cb0459e6c28abcbd885eedaf98d642
+54,1,1,tpkeeper,2018-12-18 15:17:29,https://github.com/decred/politeia/commit/7347a032e7916adbd614d349596cc61fa2e69ce2
+55,1,1,Seth Benton,2018-12-13 23:24:40,https://github.com/decred/politeia/commit/c6b0be997e878b288cc9636d34e970ff950b0be4
+56,1,1,David Hill,2018-12-13 21:22:24,https://github.com/decred/politeia/commit/702966d99cbb4514fd6befe216941536e9ba37eb
+57,1,1,Thiago de Freitas Figueiredo,2018-12-13 21:20:00,https://github.com/decred/politeia/commit/0ebf83bb701f3e8d5e48ab6f6de3e3f2d9feee5a
+58,1,1,Fernando Abolafio,2018-12-10 15:40:38,https://github.com/decred/politeia/commit/f13e494415aa6553be9d965e5b05a1fbc8475284
+59,1,1,Thiago de Freitas Figueiredo,2018-12-09 23:07:40,https://github.com/decred/politeia/commit/5b4b3d0bfba6bdb736e2e43ad2996ef8a191f38d
+60,1,1,Dave Collins,2018-12-07 22:06:53,https://github.com/decred/politeia/commit/4bb033a75b45fe7453d89305228e6117c72bf1d4
+61,1,1,lukebp,2018-12-07 21:56:56,https://github.com/decred/politeia/commit/d6f18d31d15780e5f36feac45d1e62d3e31c3bbc
+62,1,1,Marco Peereboom,2018-12-07 16:02:12,https://github.com/decred/politeia/commit/ca4cdf83f0ee5248f24940f77b8c56246c5ce508
+63,1,1,Kevin,2018-12-07 11:57:06,https://github.com/decred/politeia/commit/df92852ee6a6763347a10403a85cf3abe50dc1f2
+64,1,1,Kevin,2018-12-03 19:21:35,https://github.com/decred/politeia/commit/73e375d3d3a498d0367089e7caa4dfad4fc6178b
+65,1,1,Fernando Abolafio,2018-12-03 14:49:31,https://github.com/decred/politeia/commit/fe4e341ce046d51fe0eb0349f0e4aa3e2097b0cd
+66,1,1,Thiago de Freitas Figueiredo,2018-12-01 12:18:14,https://github.com/decred/politeia/commit/ae149f59921240a657f80b04776f4ddf646c37ff
+67,1,1,Seth Benton,2018-11-30 22:24:42,https://github.com/decred/politeia/commit/ca9879763259d7c2f79be578a9dbd4054b5a464b
+68,1,1,Victor Guedes,2018-11-30 21:20:24,https://github.com/decred/politeia/commit/d057a8aad8b5d77b60515e264624ce6ca3e3a887
+69,1,1,lukebp,2018-11-30 14:34:55,https://github.com/decred/politeia/commit/12aeb5b6ec6a1a29a8812d7f0eaf1ae53f6b1551
+70,1,1,lukebp,2018-11-30 13:57:33,https://github.com/decred/politeia/commit/6f219dcc4938ab67e27450bfc6fdc1c699c023fb
+71,1,1,lukebp,2018-11-30 13:52:29,https://github.com/decred/politeia/commit/8eaa6745760d835255212a65c19b6b2b8375de0e
+72,1,1,Thiago de Freitas Figueiredo,2018-11-30 13:51:37,https://github.com/decred/politeia/commit/f5b4f10bcb7d7fd6da36232d268a13a93925f81d
+73,1,1,lukebp,2018-11-30 13:48:10,https://github.com/decred/politeia/commit/5895a1394f7301e26b7416c4bf178c7369892981
+74,1,1,Fernando Abolafio,2018-11-29 21:08:29,https://github.com/decred/politeia/commit/b9d34d285f5eb008702c8a9e1ce146c502653ec0
+75,1,1,David Hill,2018-11-29 17:14:20,https://github.com/decred/politeia/commit/449d9c09f432f10902b0833755666bacf83d57e3
+76,1,1,Sean Durkin,2018-11-27 14:17:45,https://github.com/decred/politeia/commit/bf36bad02071753b78577d572678a43d84461f82
+77,1,1,lukebp,2018-11-19 18:18:48,https://github.com/decred/politeia/commit/3a7c386f4c726137bc67bae3f00386bde7d92287
+78,1,1,lukebp,2018-11-16 20:30:28,https://github.com/decred/politeia/commit/cc17ab6f49795e3b3035b439df74f2db6fc49079
+79,1,1,Sean Durkin,2018-11-15 16:22:31,https://github.com/decred/politeia/commit/a5ff2a88faacfa436ebcd9feaae4415db56ea54e
+80,1,1,David Hill,2018-11-14 18:08:58,https://github.com/decred/politeia/commit/12f7378558c1752ccdc3cf7f1a70109a1f18b120
+81,1,1,Tiago Alves Dulce,2018-11-14 14:42:31,https://github.com/decred/politeia/commit/c36457e458b3419b755f6d2fa5fd3c9d1e1f595a
+82,1,1,Fernando Abolafio,2018-11-14 14:22:46,https://github.com/decred/politeia/commit/4a8c7e5f207ee8b8f7f7efd5f8f260bb3a894458
+83,1,1,Fernando Abolafio,2018-11-13 14:47:20,https://github.com/decred/politeia/commit/6d7eb9834b060be02ac5ca5f250dae2c52e7e4ac
+84,1,1,lukebp,2018-11-09 16:16:52,https://github.com/decred/politeia/commit/595137dd542ab1af0df39053243465d862266e74
+85,1,1,degeri,2018-11-09 15:11:38,https://github.com/decred/politeia/commit/f66e5be1b767e572458059acde6eff0b302bcd79
+86,1,1,lukebp,2018-11-09 15:05:07,https://github.com/decred/politeia/commit/3fcf1fb0884d8ff259c810408c59c10d66f83329
+87,1,1,Fernando Abolafio,2018-11-06 14:08:57,https://github.com/decred/politeia/commit/61f5f8c4e569e3730ae3dfad4c427b8d2d40d6ee
+88,1,1,lukebp,2018-11-04 00:18:40,https://github.com/decred/politeia/commit/5ba517958a145e693c17dc807ed775dd2251777c
+89,1,1,David Hill,2018-11-01 22:41:45,https://github.com/decred/politeia/commit/f91cb149b04de6e7a942dd3fab2848ce5ad2bb8c
+90,1,1,lukebp,2018-11-01 19:59:57,https://github.com/decred/politeia/commit/7697cd02e05b76cf7782e2d952fe0e833a384a9d
+91,1,1,David Hill,2018-11-01 14:17:58,https://github.com/decred/politeia/commit/7a469b90c282ffaaa34af0804b3a92c67297a5c6
+92,1,1,Marco Peereboom,2018-10-31 20:57:32,https://github.com/decred/politeia/commit/9a765f875895bbc78e0eec0dd4d38d80cb7fcdee
+93,1,1,Fernando Abolafio,2018-10-31 13:30:20,https://github.com/decred/politeia/commit/b9e5d8a9a4a97e67cf2b1514839fd4b1708919c5
+94,1,1,Marco Peereboom,2018-10-25 20:23:10,https://github.com/decred/politeia/commit/652443ae5d247f7f4e33c9cce8a1f01d87cf3e14
+95,1,1,Sean Durkin,2018-10-23 19:38:45,https://github.com/decred/politeia/commit/7c2d6e0f82e8770ab7748d174f8cafc9fa5277ff
+96,1,1,Mawueli Kofi Adzoe,2018-10-23 18:50:26,https://github.com/decred/politeia/commit/435fe5c078f5986b73a3c17452b4013d3481edb4
+97,1,1,lukebp,2018-10-23 18:48:27,https://github.com/decred/politeia/commit/afeecd0181a0c46305c4c5917d90060a18d47b24
+98,1,1,VcTT,2018-10-23 13:24:02,https://github.com/decred/politeia/commit/42be2de0c8ba14dbedfdcf5ab70fcb153bfb7f75
+99,1,1,Fernando Abolafio,2018-10-22 18:05:16,https://github.com/decred/politeia/commit/2f360bee12b33d20aa2d75deef7d70254bd4d27c
+100,1,1,lukebp,2018-10-22 15:36:43,https://github.com/decred/politeia/commit/de5a779a76875471fcaf3d0d4661c7e057c2d5dd
+201,1,1,Sean Durkin,2018-10-21 21:16:21,https://github.com/decred/politeia/commit/9b90ffa5a6b54d8a72ea5599c67c57b7e7947e36
+202,1,1,lukebp,2018-10-19 20:06:49,https://github.com/decred/politeia/commit/8ce48ad4a1e96c045335eaef3105eb9ce1cb0711
+203,1,1,Sean Durkin,2018-10-18 15:29:16,https://github.com/decred/politeia/commit/f63e36f4f58ec9d08f088d2ad6303aaa74d389eb
+204,1,1,Sean Durkin,2018-10-18 15:02:40,https://github.com/decred/politeia/commit/7dae64e194ce416db087e0107e04ae0a335a89f0
+205,1,1,Marco Peereboom,2018-10-17 20:39:31,https://github.com/decred/politeia/commit/98481e9ffa0f17b5ca3ea392040c4fbe26eaaf38
+206,1,1,Sean Durkin,2018-10-17 19:25:11,https://github.com/decred/politeia/commit/b4f7d5d08bb33e0a86fd73fb37c8e61eb551af2e
+207,1,1,Sean Durkin,2018-10-17 15:59:59,https://github.com/decred/politeia/commit/23ff40ca9afc60b7942fa7612dc3cb390d8268f0
+208,1,1,Fernando Abolafio,2018-10-17 15:59:21,https://github.com/decred/politeia/commit/5229365a201e7eb3d76887eacad44bf86774a559
+209,1,1,Sean Durkin,2018-10-17 15:44:09,https://github.com/decred/politeia/commit/10598e3c2722b24ac219be4d69a216b27a301ce2
+210,1,1,Marco Peereboom,2018-10-17 15:43:10,https://github.com/decred/politeia/commit/908b2cc7a753ba670ed326ae51dd7d20c0875d18
+211,1,1,Sean Durkin,2018-10-17 14:22:35,https://github.com/decred/politeia/commit/0158643b6e704444d72cae14c2c8b659aac96fbd
+212,1,1,lukebp,2018-10-16 11:56:52,https://github.com/decred/politeia/commit/9f9149dbf2aa39839010cd6249827e7a68b8675c
+213,1,1,Marco Peereboom,2018-10-15 21:21:19,https://github.com/decred/politeia/commit/4cd2f3bb550914e955afbc44585a13c5aa417975
+214,1,1,Fernando Abolafio,2018-10-15 20:27:33,https://github.com/decred/politeia/commit/d9bc6c41ac3a856e7e342a4326dd6f271c572d2a
+215,1,1,Marco Peereboom,2018-10-15 20:20:04,https://github.com/decred/politeia/commit/567bd319d2f4287a4f093c0daeb9bf4dd1095d10
+216,1,1,Tiago Alves Dulce,2018-10-15 18:16:12,https://github.com/decred/politeia/commit/77bdc6c0c23d895a06df4767696cbfd8a4ffd158
+217,1,1,Marco Peereboom,2018-10-15 18:15:08,https://github.com/decred/politeia/commit/72d147f52dea2723d3f7ee0082144a8183cf722c
+218,1,1,Fernando Abolafio,2018-10-15 17:27:33,https://github.com/decred/politeia/commit/369c42e159f1125e0ce1107435cb1a989998d64b
+219,1,1,lukebp,2018-10-15 15:40:09,https://github.com/decred/politeia/commit/498ef3b79e3b3546d725ed6887214bd6e971e61a
+220,1,1,Marco Peereboom,2018-10-12 17:54:30,https://github.com/decred/politeia/commit/5a88ae0a6619503a91314ba40831bb3a11e19dc4
+221,1,1,Marco Peereboom,2018-10-09 14:53:46,https://github.com/decred/politeia/commit/da69903f25d4474baed325c64ff668f60e70a7ad
+222,1,1,lukebp,2018-10-09 14:41:42,https://github.com/decred/politeia/commit/7bbb0871ed2ac5030615e24629108f229617cbec
+223,1,1,Marco Peereboom,2018-10-05 20:17:26,https://github.com/decred/politeia/commit/8fdc8395b1b3c851c8b351778f14fbdbd83f78b8
+224,1,1,David Hill,2018-10-05 14:45:20,https://github.com/decred/politeia/commit/0a3a75ba7481a6d62950003caae4a34ecf73d367
+225,1,1,Fernando Abolafio,2018-10-05 13:31:49,https://github.com/decred/politeia/commit/1a8c9421cac2e1257ebec16d52001aa0a483a148
+226,1,1,lukebp,2018-10-04 17:51:21,https://github.com/decred/politeia/commit/500d4f8cb73bbb33fc60f565c444fff14f5b4501
+227,1,1,lukebp,2018-10-03 17:11:10,https://github.com/decred/politeia/commit/fe3510d73cc607af06d47e155e59fae041824991
+228,1,1,Tiago Alves Dulce,2018-10-03 15:32:28,https://github.com/decred/politeia/commit/ec0bed452cef859d4596c83fb2e180c7b6b7900a
+229,1,1,Fernando Abolafio,2018-10-02 15:58:55,https://github.com/decred/politeia/commit/08f854c6877fdc98bc91560bd4bbb56661cfa686
+230,1,1,Marco Peereboom,2018-10-01 15:50:15,https://github.com/decred/politeia/commit/c3217fd27d1b966defc79201c0d90764cbba64ff
+231,1,1,Marco Peereboom,2018-09-28 13:26:23,https://github.com/decred/politeia/commit/2b184624aa7880cf729488d3b0b727dac9c3424c
+232,1,1,Thiago de Freitas Figueiredo,2018-09-27 14:15:43,https://github.com/decred/politeia/commit/55e6706959765422d01818983777047a5ec18893
+233,1,1,Marco Peereboom,2018-09-26 22:34:08,https://github.com/decred/politeia/commit/f4c075780bed786a1faebe29b1692512dbe44b36
+234,1,1,lukebp,2018-09-26 20:48:53,https://github.com/decred/politeia/commit/edd35ad8aca0cd6e833355ed9ca3f910ad80f2c0
+235,1,1,lukebp,2018-09-26 20:43:06,https://github.com/decred/politeia/commit/be702439e795a8e18cd82dd2c701a495c80fdba0
+236,1,1,lukebp,2018-09-26 20:42:26,https://github.com/decred/politeia/commit/ccf106088ce0372efd9ea097153528ee92788db5
+237,1,1,Fernando Abolafio,2018-09-25 17:15:21,https://github.com/decred/politeia/commit/2ad0e1d5da0d5d37d4423ab011efee043df5772b
+238,1,1,lukebp,2018-09-25 13:59:13,https://github.com/decred/politeia/commit/6a514bb271c324ab25f9bbe0b204727c6de7dc1f
+239,1,1,lukebp,2018-09-25 13:55:56,https://github.com/decred/politeia/commit/8df6ae6c9c079df6499ac25ccb1be2c9394851b0
+240,1,1,lukebp,2018-09-19 20:56:06,https://github.com/decred/politeia/commit/2729f77d1727ab21bdb043866c51f330e5e5833e
+241,1,1,lukebp,2018-09-18 21:44:24,https://github.com/decred/politeia/commit/714024a05ed9cc4d43b7da92c8744931f91d33b7
+242,1,1,lukebp,2018-09-18 16:01:44,https://github.com/decred/politeia/commit/f0622b64920f1be163964be4e46e0da1547016bf
+243,1,1,lukebp,2018-09-17 21:12:02,https://github.com/decred/politeia/commit/b395e01336dfd86d430b30fd4a50c6033b65e6a3
+244,1,1,lukebp,2018-09-11 20:03:14,https://github.com/decred/politeia/commit/52f2c7d6e11b90d710ac4fa4a4079ca933de46bb
+245,1,1,Fernando Abolafio,2018-09-11 15:26:15,https://github.com/decred/politeia/commit/29b134cfd2e1f3d025144d334835623a129df47a
+246,1,1,lukebp,2018-09-10 18:33:21,https://github.com/decred/politeia/commit/d6313578e386990b5eb3716531e72a999dd938b8
+247,1,1,Marco Peereboom,2018-09-07 19:01:02,https://github.com/decred/politeia/commit/5f2637c6596e973e17d3c4e87a2e69315bbc5ce1
+248,1,1,Tiago Alves Dulce,2018-09-07 17:44:08,https://github.com/decred/politeia/commit/29db563ff62cadcdf123a75d222303b874979e32
+249,1,1,VcTT,2018-09-06 15:33:43,https://github.com/decred/politeia/commit/9e832d2deac25b94d5a9d94eddc9ad5e2cbc2d3f
+250,1,1,Sean Durkin,2018-09-06 14:43:52,https://github.com/decred/politeia/commit/7ca6c4ca572a538c6b9a7cd4fe583f85b8d688a4
+251,1,1,lukebp,2018-09-06 14:28:03,https://github.com/decred/politeia/commit/3f777277f5e993e8a1c2b0bddcff876d855cac23
+252,1,1,Fernando Abolafio,2018-09-05 20:18:28,https://github.com/decred/politeia/commit/a6670587bec450f0d80ea713df1d05d1aa9ceb62
+253,1,1,lukebp,2018-09-05 17:33:47,https://github.com/decred/politeia/commit/3554204bd1d622bdafd044072a81fc26723e4f56
+254,1,1,lukebp,2018-09-05 16:18:49,https://github.com/decred/politeia/commit/9c5b89a5574ea4f35a31e91269cf0cf02522eb3c
+255,1,1,lukebp,2018-09-05 12:50:24,https://github.com/decred/politeia/commit/c250d735f8b4302421e8d30277aa0b542174ee5b
+256,1,1,Tiago Alves Dulce,2018-09-04 21:14:55,https://github.com/decred/politeia/commit/0d89503a62fc4ac0e4db34cfd57000d4a1e94c4a
+257,1,1,Fernando Abolafio,2018-09-04 21:00:55,https://github.com/decred/politeia/commit/7d5671813a922251bd9f2cc7dff49e8453234323
+258,1,1,Fernando Abolafio,2018-09-04 13:55:40,https://github.com/decred/politeia/commit/34b3dc53b238d7a2df98e7857551af82a926ccf7
+259,1,1,Fernando Abolafio,2018-08-31 21:34:02,https://github.com/decred/politeia/commit/1074ff144d535f6ce2d9dc11737de6e8bf2f254a
+260,1,1,David Hill,2018-08-31 14:32:24,https://github.com/decred/politeia/commit/b87501f12ca7007a56283e98eccdc87227853ab7
+261,1,1,Fernando Abolafio,2018-08-31 14:11:04,https://github.com/decred/politeia/commit/15fb43ea1b1e064619e1e8e290eba695e18c9a51
+262,1,1,David Hill,2018-08-30 16:54:00,https://github.com/decred/politeia/commit/95c949968a5b9a9657fbfa8e23d0942f7304a571
+263,1,1,lukebp,2018-08-30 16:52:32,https://github.com/decred/politeia/commit/349ff21bf75600a604a244b84c2d435cc9241eb0
+264,1,1,Fernando Abolafio,2018-08-30 14:47:44,https://github.com/decred/politeia/commit/774f62a4e3758370641971bbee79667ef0462b4e
+265,1,1,Marco Peereboom,2018-08-30 14:39:04,https://github.com/decred/politeia/commit/ada6ebdf607b06d6a63ec4df144527f6c88f1d01
+266,1,1,David Hill,2018-08-29 20:57:00,https://github.com/decred/politeia/commit/22fad06714872ae985ae439974a8d9b7ac9385f1
+267,1,1,Marco Peereboom,2018-08-29 20:04:22,https://github.com/decred/politeia/commit/40d8f17928dae69c27ea6b5d4f855cb3cce79328
+268,1,1,Fernando Abolafio,2018-08-20 15:26:30,https://github.com/decred/politeia/commit/4f006056ed85c7d83011b0e6afbdc86cc4109f44
+269,1,1,Fernando Abolafio,2018-08-13 17:46:55,https://github.com/decred/politeia/commit/9bc5ceb6c3bbdeb39ce3177aed0a9ddd196326a2
+270,1,1,lukebp,2018-08-11 12:45:45,https://github.com/decred/politeia/commit/6faaf11599625f5522a8b3179f975e458e758531
+271,1,1,Sean Durkin,2018-08-08 23:59:14,https://github.com/decred/politeia/commit/a0bade8bd0139394f8ec016efe7f9e9bbcefb606
+272,1,1,David Hill,2018-08-08 18:46:38,https://github.com/decred/politeia/commit/4189ae24dcb711aea501ea698d890a60aa07d3a1
+273,1,1,Sean Durkin,2018-08-02 15:09:13,https://github.com/decred/politeia/commit/09f4d067e6712d7a167594771495017b6a347926
+274,1,1,Sean Durkin,2018-08-02 14:20:52,https://github.com/decred/politeia/commit/ea349fa9e76ff58221ef71b98d6514137f43b811
+275,1,1,Sean Durkin,2018-08-02 14:14:10,https://github.com/decred/politeia/commit/1db07b22cab9274f1c66b946dc3e7c202553bfcf
+276,1,1,Sean Durkin,2018-08-01 10:16:54,https://github.com/decred/politeia/commit/cbabfafebadeb40a9f7046d8e8e5901ed8da8662
+277,1,1,lukebp,2018-08-01 04:51:54,https://github.com/decred/politeia/commit/afc132b4ef97fa7074c1e2ade6ccb171117b457a
+278,1,1,lukebp,2018-07-30 15:18:32,https://github.com/decred/politeia/commit/0bc359bb67b91d30dc95561850da50e6d8f2d676
+279,1,1,lukebp,2018-07-27 10:51:22,https://github.com/decred/politeia/commit/fd0cfea103849bc7c782a7dd647aba439f90cce3
+280,1,1,Sean Durkin,2018-07-26 14:20:23,https://github.com/decred/politeia/commit/0762b1cf1b22076a428b972fad996b9efe13acec
+281,1,1,lukebp,2018-07-25 15:27:47,https://github.com/decred/politeia/commit/a146e3272e32727f9c54c38c8fdd5aab48ee9f8f
+282,1,1,VcTT,2018-07-25 14:54:04,https://github.com/decred/politeia/commit/3c9e90bd7ca00a6c0ea37c318d4c8b469e95c1e8
+283,1,1,Hector Sanjuan,2018-07-25 13:18:40,https://github.com/decred/politeia/commit/091909b9485464f823173ff808f822fba38de87d
+284,1,1,VcTT,2018-07-25 13:13:53,https://github.com/decred/politeia/commit/914c2fada4867ce49fd3bd8a2ab11170fbfdb381
+285,1,1,lukebp,2018-07-23 22:19:07,https://github.com/decred/politeia/commit/83e52c061c68a09631f46b8998532c8b6ba11339
+286,1,1,Fernando Abolafio,2018-07-20 20:40:47,https://github.com/decred/politeia/commit/63410369153a9705acb33a1385cb3925958db04a
+287,1,1,David Hill,2018-07-18 23:31:30,https://github.com/decred/politeia/commit/c0565a7aadd5f3c2a1f7b0c60bed260d5103821a
+288,1,1,Sean Durkin,2018-07-18 13:39:10,https://github.com/decred/politeia/commit/f7c55602cd2a4008fcfdc0955de06ed0416f708a
+289,1,1,Marco Peereboom,2018-07-17 16:55:52,https://github.com/decred/politeia/commit/9143989b65d752e1cafcfebce3c836777604ed3e
+290,1,1,Fernando Abolafio,2018-07-17 14:21:07,https://github.com/decred/politeia/commit/568b9904d9bf1f17d8b6e0b9d6d4dc06103263fb
+291,1,1,Sean Durkin,2018-07-13 12:52:05,https://github.com/decred/politeia/commit/a2186930bc72908293fd36215af57bcffcdfdd9c
+292,1,1,Fernando Abolafio,2018-07-13 12:16:12,https://github.com/decred/politeia/commit/1655ad3fa25bfa126d21a29d44f0831838a9d5c4
+293,1,1,Sean Durkin,2018-07-12 00:01:36,https://github.com/decred/politeia/commit/da44c1613bffb0f52688e79eacc900f5b4b954a3
+294,1,1,Sean Durkin,2018-07-06 13:27:07,https://github.com/decred/politeia/commit/dd24a0a387965b3175490ec7d59c2a89cb2e885d
+295,1,1,Tiago Alves Dulce,2018-07-05 13:17:03,https://github.com/decred/politeia/commit/5c82398f935046f7ef8eee6245198daeb3349c2e
+296,1,1,Sean Durkin,2018-07-03 16:01:55,https://github.com/decred/politeia/commit/faff72eb2e4a2cdd631e800040e9af37918cf2f1
+297,1,1,Marco Peereboom,2018-07-03 15:12:38,https://github.com/decred/politeia/commit/d536b990e39ea7fb9623ef74eb9450e2dd7cb6bc
+298,1,1,Marco Peereboom,2018-07-03 11:14:21,https://github.com/decred/politeia/commit/cf642bed5da5dc3aa25fdae3c61c30c185dbdacf
+299,1,1,Tiago Alves Dulce,2018-07-03 08:48:45,https://github.com/decred/politeia/commit/af31e70aa60a20933c8525ee326f097a045ac8b8
+300,1,1,lte13,2018-07-02 11:24:40,https://github.com/decred/politeia/commit/dbde73bb14a7fdc6832f4b1ee38fc72bc7933152
+301,1,1,Ramon Recuero,2018-07-02 11:05:45,https://github.com/decred/politeia/commit/ec3f1839d71a53e333b31e9dabc41e8581955b6b
+302,1,1,Sean Durkin,2018-06-29 15:47:57,https://github.com/decred/politeia/commit/ab2eaee225e22d1dc71001555e2b44d0ae3579e6
+303,1,1,Sean Durkin,2018-06-29 15:47:15,https://github.com/decred/politeia/commit/647e7dbefab3d9a2b0d757d5c7b08f85c83e838b
+304,1,1,Fernando Abolafio,2018-06-29 15:34:48,https://github.com/decred/politeia/commit/d82247aa31177ce807f9c2495e84451e034066d2
+305,1,1,Tiago Alves Dulce,2018-06-26 22:53:47,https://github.com/decred/politeia/commit/d150d914de0d0e4f5cc44b9f73c21fcb09427dae
+306,1,1,Fernando Abolafio,2018-06-25 16:36:38,https://github.com/decred/politeia/commit/f5ee11c3ec0bf15e53cadfb70156a063106d39ff
+307,1,1,RichardRed0x,2018-06-25 16:29:23,https://github.com/decred/politeia/commit/d3447751372bdd881b64d04c49a09b0b1522ed2c
+308,1,1,Sean Durkin,2018-06-25 16:13:17,https://github.com/decred/politeia/commit/d339b73812ca8be442618430dcf8857a3437ba05
+309,1,1,Tiago Alves Dulce,2018-06-25 14:47:08,https://github.com/decred/politeia/commit/44c3bbe4908df98ae6c11c02f388b1dad3c0872e
+310,1,1,Sean Durkin,2018-06-22 14:04:47,https://github.com/decred/politeia/commit/321b7b0a5c64fd6c5d5eba1edb2ca4d3e47ce6e8
+311,1,1,Sean Durkin,2018-06-22 14:04:17,https://github.com/decred/politeia/commit/701031e4dafec087badd6e01dd9635ea6b028f3a
+312,1,1,Marco Peereboom,2018-06-22 12:02:09,https://github.com/decred/politeia/commit/8cb8ad3270182ee5b2e21dab13ee5d0fd55f5e1b
+313,1,1,lukebp,2018-06-22 10:36:52,https://github.com/decred/politeia/commit/2410f36f9739c50f926591a2a216c8d8d115678f
+314,1,1,Fernando Abolafio,2018-06-20 21:28:29,https://github.com/decred/politeia/commit/53dbbdec3dbaef0ba2d1f2929b621a6162d2d64e
+315,1,1,Fernando Abolafio,2018-06-20 17:39:39,https://github.com/decred/politeia/commit/3d7f1b2ba767b5ef8793ba3c129d34dabbdf0638
+316,1,1,Marco Peereboom,2018-06-19 16:51:07,https://github.com/decred/politeia/commit/25df51a6b1ff449eba522d0f85f4395671ba1317
+317,1,1,Marco Peereboom,2018-06-19 12:17:56,https://github.com/decred/politeia/commit/7f1171348954227150f66215b7de52bfdc9132ce
+318,1,1,lukebp,2018-06-15 09:03:04,https://github.com/decred/politeia/commit/fa830b03f6984b6c45a0a470ab0680b82f56ea2c
+319,1,1,Marco Peereboom,2018-06-13 15:54:26,https://github.com/decred/politeia/commit/5fd08a0933ebc3e279d59666a2f8f717c647b1b9
+320,1,1,Decebal Dobrica,2018-06-13 14:35:20,https://github.com/decred/politeia/commit/a449b145767d1478b55c593b62048a9030a99820
+321,1,1,Sean Durkin,2018-06-11 21:14:02,https://github.com/decred/politeia/commit/dab0a679c407a1818b7688d132ccf16a9a0f79ab
+322,1,1,Marco Peereboom,2018-06-11 21:06:43,https://github.com/decred/politeia/commit/61e8e3376894ebba9486d3b23412f5e3edb5a216
+323,1,1,Fernando Abolafio,2018-06-11 20:38:11,https://github.com/decred/politeia/commit/9333ecd896d4c75bf67b994a3b527a5875fae6d9
+324,1,1,David Hill,2018-06-07 21:59:53,https://github.com/decred/politeia/commit/fe3bdead1b7b665770f016c3d29b1efb33f2711f
+325,1,1,Marco Peereboom,2018-06-07 17:19:34,https://github.com/decred/politeia/commit/ab2b0786d2f06104f3caa6b8f15702afa7e08089
+326,1,1,Sean Durkin,2018-06-05 19:57:06,https://github.com/decred/politeia/commit/8b12d78fbc24f5f0e1b8012f8efd597e0f0f2dc4
+327,1,1,lukebp,2018-06-04 08:25:50,https://github.com/decred/politeia/commit/17096922feb9b4a99cc35e64d75fcbadc0ffc726
+328,1,1,lukebp,2018-05-31 15:57:16,https://github.com/decred/politeia/commit/f2625bbd7c72314d5ecff01fc7198da40d4f2df0
+329,1,1,Sean Durkin,2018-05-30 14:10:47,https://github.com/decred/politeia/commit/0b010d92827c58d81aee662e1c18fc3110d1c734
+330,1,1,Luke Powell,2018-05-25 12:29:27,https://github.com/decred/politeia/commit/e4c6bec23b1e2a3a38096df798224899f2636d4f
+331,1,1,Sean Durkin,2018-05-23 15:54:35,https://github.com/decred/politeia/commit/dd676a6a8bd34f2dd008e81b62388c9817b08049
+332,1,1,Sean Durkin,2018-05-21 17:56:19,https://github.com/decred/politeia/commit/8ea40eb94c8159f151016034de6ae2243c865f76
+333,1,1,Fernando Abolafio,2018-05-18 16:37:00,https://github.com/decred/politeia/commit/bb70975e994a0be29805be0d7fea66b4564c2859
+334,1,1,Sean Durkin,2018-05-15 13:26:53,https://github.com/decred/politeia/commit/9ee62142fd75582e8c2a13a673e046858ce2efe4
+335,1,1,Luke Powell,2018-05-11 17:56:41,https://github.com/decred/politeia/commit/fb51368254d7807a5d3e0c5c71e9b9e751977f8c
+336,1,1,Sean Durkin,2018-05-11 13:11:32,https://github.com/decred/politeia/commit/6e64cf2836a85e42c54b7cbe65f8146a082b4fba
+337,1,1,Fernando Abolafio,2018-05-10 15:04:18,https://github.com/decred/politeia/commit/b900fc8a301b36c10f7ae583cf4127d68953c9b6
+338,1,1,Fernando Abolafio,2018-05-09 20:28:53,https://github.com/decred/politeia/commit/5be9c863a34827beabffc5ed01c46b8a10834dde
+339,1,1,Fernando Abolafio,2018-05-09 18:08:51,https://github.com/decred/politeia/commit/00735c2c598e8b2197064d5c8eb32ae0e1de10c1
+340,1,1,Everton Melo,2018-05-08 21:26:45,https://github.com/decred/politeia/commit/0ebd4769ea438562531cc5f517c3914d777fa95f
+341,1,1,David Hill,2018-05-03 15:20:39,https://github.com/decred/politeia/commit/a91b44000b79a7230829a62997405ab091d073b6
+342,1,1,VcTT,2018-05-03 15:12:05,https://github.com/decred/politeia/commit/cd7ade4d74d44837e971b2894a35e639e5f13ebd
+343,1,1,VcTT,2018-04-30 14:55:28,https://github.com/decred/politeia/commit/9e227dbb7e1e4c4f2585c1a7f44ef16c1359fb3f
+344,1,1,Marco Peereboom,2018-04-20 18:51:14,https://github.com/decred/politeia/commit/228a8413b2373aedb7e96c74397800447f141e8d
+345,1,1,Marco Peereboom,2018-04-17 18:25:33,https://github.com/decred/politeia/commit/78d939066c4f2f1ff050db0cfc357e7c35240593
+346,1,1,Marco Peereboom,2018-04-17 17:46:55,https://github.com/decred/politeia/commit/eaa75c5549035047c876849e86ac9609a3d30b34
+347,1,1,Marco Peereboom,2018-04-17 16:16:22,https://github.com/decred/politeia/commit/882d531c16b7ef56579646823b185d836dfedc8a
+348,1,1,Marco Peereboom,2018-04-16 21:06:43,https://github.com/decred/politeia/commit/bb59d199f3a395b4a9e2d2ce4e482c00aacf8666
+349,1,1,Marco Peereboom,2018-04-16 19:56:45,https://github.com/decred/politeia/commit/f509f9e74aa6030d1a35053464f381f0f93319c8
+350,1,1,Marco Peereboom,2018-04-16 17:52:39,https://github.com/decred/politeia/commit/a818ad4eb134193cbc32c78e0b8eb47688f23be5
+351,1,1,Marco Peereboom,2018-04-13 15:43:30,https://github.com/decred/politeia/commit/6cb4150de70c6e49adf12b413c871acc924e3417
+352,1,1,Victor Oliveira,2018-04-12 21:56:35,https://github.com/decred/politeia/commit/3308450f482b7937840dee25ad357ec0ee929b25
+353,1,1,Victor Oliveira,2018-04-12 20:22:58,https://github.com/decred/politeia/commit/de601294199c4b3d034dba68a1aa7843fc0b5a81
+354,1,1,David Hill,2018-04-12 20:22:17,https://github.com/decred/politeia/commit/5433e70e6652a568c6013dcbabfbf7617d42b0c2
+355,1,1,David Hill,2018-04-10 20:53:51,https://github.com/decred/politeia/commit/6d444a5f107758e1a42e8400d538068066f5b0e8
+356,1,1,Marco Peereboom,2018-04-10 16:01:39,https://github.com/decred/politeia/commit/fd86d98c7baa6d59b18a641243cc31a96c9c9e79
+357,1,1,David Hill,2018-04-03 16:37:34,https://github.com/decred/politeia/commit/f666a193a2f087a69636acb44b026556197cbea5
+358,1,1,David Hill,2018-04-03 16:37:14,https://github.com/decred/politeia/commit/8a005a38b5a4f83e08f3e155590c7b382df06e00
+359,1,1,Sean Durkin,2018-03-30 16:03:07,https://github.com/decred/politeia/commit/3482dab52233ec9c51d1ca97636a0435935ae2a2
+360,1,1,sudoscript,2018-03-20 18:55:53,https://github.com/decred/politeia/commit/e6eedfdf0f63953f872e8af649e895dcc5b8caa3
+361,1,1,Sean Durkin,2018-03-13 14:33:34,https://github.com/decred/politeia/commit/fe537f99c37641b0a26a3d9a4c91e90abbe62c6d
+362,1,1,David Hill,2018-02-16 18:31:03,https://github.com/decred/politeia/commit/b78339ca21cc4423ff08fd441730a1fb12083b9c
+363,1,1,AlanL1,2018-02-13 21:45:03,https://github.com/decred/politeia/commit/22f67dc53ce4807fae021ad822004c21b3010748
+364,1,1,AlanL1,2018-02-08 15:00:15,https://github.com/decred/politeia/commit/ba21c380b30411de0a83ee11c579377a91068323
+365,1,1,Victor Oliveira,2018-02-06 15:35:22,https://github.com/decred/politeia/commit/54f8325773da51865c4c84315c82cdfed0f31387
+366,1,1,Sean Durkin,2018-02-06 15:33:40,https://github.com/decred/politeia/commit/2b6061faf1915c7adc4629206e20e9fd089b97c1
+367,1,1,Sean Durkin,2018-01-23 16:23:50,https://github.com/decred/politeia/commit/30cc2c072c714c9de2ba73392591175087aae3b2
+368,1,1,Fernando Abolafio,2018-01-23 14:33:50,https://github.com/decred/politeia/commit/79d261371994174e87fe890c53d157b9e5002540
+369,1,1,Sean Durkin,2018-01-23 14:31:51,https://github.com/decred/politeia/commit/05cb9c3a170f9d787ce9c45b288794aa71ba151d
+370,1,1,Fernando Abolafio,2018-01-22 15:39:22,https://github.com/decred/politeia/commit/fe356e79242716b66610ed20bcfa2fff7f2afa92
+371,1,1,Sean Durkin,2018-01-22 15:34:57,https://github.com/decred/politeia/commit/84c88f9cced904ce81281d34e8e1bb178c5662f6
+372,1,1,Sean Durkin,2018-01-16 17:20:55,https://github.com/decred/politeia/commit/b38e4d1621af574d46fc25440285104e191f9f81
+373,1,1,Ricardo Geraldes,2018-01-15 22:30:35,https://github.com/decred/politeia/commit/b7b6b3f5eadddc1377eb90cf49427025ff431b75
+374,1,1,Sean Durkin,2018-01-15 17:23:20,https://github.com/decred/politeia/commit/3013d28f27793231cbec2f3502cb3c7b79678307
+375,1,1,Sean Durkin,2018-01-15 17:22:51,https://github.com/decred/politeia/commit/a7fcd88ae74490952f226abd315e477c990f3b10
+376,1,1,Sean Durkin,2018-01-15 17:21:57,https://github.com/decred/politeia/commit/66118ebd8bb4699897e99473ca1c76cd255b0b4b
+377,1,1,Sean Durkin,2018-01-08 15:37:52,https://github.com/decred/politeia/commit/d4ff16ef37371603e7505369a3c2bc4158893a17
+378,1,1,Sean Durkin,2018-01-08 15:29:39,https://github.com/decred/politeia/commit/8404a6f8dd8a6c6a8f6ee2b7b86e04ffd8cb9e05
+379,1,1,jolan,2017-12-21 20:54:52,https://github.com/decred/politeia/commit/d001f3d55e0ab4410f52d7ff82b6ed6d8951a887
+380,1,1,Marco Peereboom,2017-12-20 14:17:14,https://github.com/decred/politeia/commit/1e3b34b822a433429db60e2553bf29b504836277
+381,1,1,Marco Peereboom,2017-12-15 20:50:59,https://github.com/decred/politeia/commit/0cf238589ba0426c4b20b39e9d7287f795255552
+382,1,1,Marco Peereboom,2017-12-15 19:33:50,https://github.com/decred/politeia/commit/2f9ba653c5187cc7e5dfd2e0ae731cdff84ac70b
+383,1,1,jolan,2017-12-15 18:12:30,https://github.com/decred/politeia/commit/68e79c530907b6b09f8cbe9e4330df55cdef2335
+384,1,1,jolan,2017-12-13 16:18:25,https://github.com/decred/politeia/commit/93db6cdfd9653c3207afb1b0c1a6a776662919bd
+385,1,1,Marco Peereboom,2017-12-07 22:12:10,https://github.com/decred/politeia/commit/737ae59341bdbab3dfe611fe18aaa6ffc3e3371e
+386,1,1,Victor Oliveira,2017-12-07 15:21:57,https://github.com/decred/politeia/commit/c097aaa376ca69bdab79d5125d587a396e0f30e9
+387,1,1,Marco Peereboom,2017-12-04 15:15:27,https://github.com/decred/politeia/commit/841bcaeff75605f8be134daba5937056fc4739fd
+388,1,1,Ricardo Geraldes,2017-12-01 19:40:32,https://github.com/decred/politeia/commit/1fd012b2d8116e1568fd564e4a7d93e5e027441e
+389,1,1,David Hill,2017-12-01 19:21:42,https://github.com/decred/politeia/commit/0c157db305e73ca13f57d6fd1353c409f9a9a1b5
+390,1,1,Marco Peereboom,2017-12-01 19:16:32,https://github.com/decred/politeia/commit/d6c94306bb210a610117ef29508e2a28b2fca24e
+391,1,1,David Hill,2017-12-01 19:06:44,https://github.com/decred/politeia/commit/5ce7c37a72576b1705735c35f1ea45ad13ffdad0
+392,1,1,Marco Peereboom,2017-12-01 18:48:57,https://github.com/decred/politeia/commit/9bcdda3ef64f5be0c062004f3539c44478f8180a
+393,1,1,Marco Peereboom,2017-12-01 18:28:57,https://github.com/decred/politeia/commit/a82cd66548c5015f531fa1f62aa5b5bc36a5e878
+394,1,1,Marco Peereboom,2017-12-01 04:03:45,https://github.com/decred/politeia/commit/19a5f99eb70ad52517ed127d36c3142df088a67f
+395,1,1,Sean Durkin,2017-12-01 03:59:37,https://github.com/decred/politeia/commit/c8986fced41c6505749b657a7a57cc7de35eabde
+396,1,1,Sean Durkin,2017-12-01 03:33:51,https://github.com/decred/politeia/commit/0cf25f4afe6d9f9db133585481dfb2131c625dff
+397,1,1,Sean Durkin,2017-12-01 03:20:42,https://github.com/decred/politeia/commit/60adda783d35e45caf08bcb39bf6499808d490c0
+398,1,1,Marco Peereboom,2017-11-30 18:01:40,https://github.com/decred/politeia/commit/76a52d3f52218c4545599d4b2d36f391f69de8d3
+399,1,1,jolan,2017-11-30 13:26:43,https://github.com/decred/politeia/commit/92b4de7a2126e408736c3eb36e5102a104190891
+400,1,1,Sean Durkin,2017-11-30 13:23:28,https://github.com/decred/politeia/commit/362f717f571053e6b3ec2f5233930a5104345299
+401,1,1,Victor Oliveira,2017-11-20 19:55:35,https://github.com/decred/politeia/commit/452d01339c164939906e2ccba1df9a2f2a897ef2
+402,1,1,Sean Durkin,2017-11-20 15:52:00,https://github.com/decred/politeia/commit/bc5acef640423fad99a898bf612fb677a65857dc
+403,1,1,Sean Durkin,2017-11-20 15:49:59,https://github.com/decred/politeia/commit/a0cb88495d849bfec71848cf6361b1df1ed2c5a8
+404,1,1,Marco Peereboom,2017-11-14 20:35:16,https://github.com/decred/politeia/commit/7899836e2f580f68c2ec6de6e4ba263ba791c461
+405,1,1,Sean Durkin,2017-11-13 19:13:25,https://github.com/decred/politeia/commit/60b0aeae221bb91243edd59cf5a8f7a6a96fc6be
+406,1,1,Sean Durkin,2017-11-13 19:04:48,https://github.com/decred/politeia/commit/449270d5881aef0c6c4ecba68cd6594d64d0c070
+407,1,1,Marco Peereboom,2017-11-13 14:42:53,https://github.com/decred/politeia/commit/93f6acd0dc7dba5233a2271f1f82da741cad2ef6
+408,1,1,vctt94,2017-11-13 13:25:09,https://github.com/decred/politeia/commit/a8c1337b169254b24c9d9c388bb748cef01b266f
+409,1,1,Ricardo Geraldes,2017-11-10 18:09:56,https://github.com/decred/politeia/commit/3a318af082457b19909a91aa853ff68107152b92
+410,1,1,Ricardo Geraldes,2017-11-09 18:35:39,https://github.com/decred/politeia/commit/b56de162f1cebe2b3a050a15cb5a5c6832cc592b
+411,1,1,Marco Peereboom,2017-11-09 15:56:40,https://github.com/decred/politeia/commit/34b0738bc81bc2237594ee31e32e8a22a158677d
+412,1,1,Marco Peereboom,2017-11-09 15:56:10,https://github.com/decred/politeia/commit/b09eca5e738f46837bc2b2283c0e8c8438379e3e
+413,1,1,Sean Durkin,2017-11-09 15:31:45,https://github.com/decred/politeia/commit/0bba4c00cbbb537048af23d50b7e4a6ad5672016
+414,1,1,Sean Durkin,2017-11-08 14:46:35,https://github.com/decred/politeia/commit/4feb70a39c9d55cd334c7094981dc14cd483c167
+415,1,1,Ricardo Geraldes,2017-11-07 02:36:45,https://github.com/decred/politeia/commit/250c6866f78a4c79c10a6e8011dbc00659b2db23
+416,1,1,Marco Peereboom,2017-11-06 22:19:33,https://github.com/decred/politeia/commit/a9910da50026ce41168c74c0d6766de33a47bec5
+417,1,1,Sean Durkin,2017-11-05 19:12:11,https://github.com/decred/politeia/commit/2a6d154fca8209c635d1280c7e5d4a3c555fe9ad
+418,1,1,Sean Durkin,2017-11-02 16:03:34,https://github.com/decred/politeia/commit/f8fe0171df2fe2e0fb4c598795e08807396ec799
+419,1,1,Sean Durkin,2017-10-31 15:40:03,https://github.com/decred/politeia/commit/832f564a32664e98085c4db450a3eedbf8507018
+420,1,1,Sean Durkin,2017-10-31 15:35:22,https://github.com/decred/politeia/commit/7281fbbbdfe8606fd68e3997f87863a92fcc88dc
+421,1,1,Sean Durkin,2017-10-28 18:26:27,https://github.com/decred/politeia/commit/0e1e43ace2e65424d95b3d95175e480beece5768
+422,1,1,Sean Durkin,2017-10-26 15:31:39,https://github.com/decred/politeia/commit/081f7389535d4aa26da5a69c9f58666432775240
+423,1,1,Marco Peereboom,2017-10-25 16:47:20,https://github.com/decred/politeia/commit/a2edaa8efac021043e30a1dd1f39e48b720a9635
+424,1,1,David Hill,2017-10-25 16:29:57,https://github.com/decred/politeia/commit/e3a6c9ae2bf87fa4c89a29bee6850b8975aae1a9
+425,1,1,Marco Peereboom,2017-10-25 13:30:50,https://github.com/decred/politeia/commit/776880fa71240ed984dc15307756a2dac5b08712
+426,1,1,Sean Durkin,2017-10-24 17:23:36,https://github.com/decred/politeia/commit/8521830be2daa5f0b6b453041dffe78b069462f0
+427,1,1,David Hill,2017-10-24 16:41:16,https://github.com/decred/politeia/commit/86ab771c331c5faa2c6a3af29dbaeaa2f9f51139
+428,1,1,Sean Durkin,2017-10-24 13:48:35,https://github.com/decred/politeia/commit/5c4c10f7ea3a082578756283b7c61cb6e9263aba
+429,1,1,Sean Durkin,2017-10-23 17:57:38,https://github.com/decred/politeia/commit/fb59565c63aed075308522d4a4a8eed0c6cc8443
+430,1,1,Sean Durkin,2017-10-23 12:33:23,https://github.com/decred/politeia/commit/ce724341b6f1422c1258e0f6866f15960bea5bb3
+431,1,1,Sean Durkin,2017-10-23 12:21:48,https://github.com/decred/politeia/commit/6199a2f6f1a7e63f793e6fbc1c5c83cf0b5c1119
+432,1,1,Sean Durkin,2017-10-20 15:50:37,https://github.com/decred/politeia/commit/d252d78ac40791a2059f3610f3ac5d25d26065d2
+433,1,1,Marco Peereboom,2017-10-19 20:35:50,https://github.com/decred/politeia/commit/20952e498a7d6ba4d716cb3d0ee1311fc227db57
+434,1,1,Marco Peereboom,2017-10-19 18:56:44,https://github.com/decred/politeia/commit/bbc80aef219a988d5d0ee6d6a0183f8dfe9f6e3f
+435,1,1,Sean Durkin,2017-10-19 16:36:10,https://github.com/decred/politeia/commit/333c72521ea9828dcf72d954e369f693a56f8b59
+436,1,1,Marco Peereboom,2017-10-18 20:35:59,https://github.com/decred/politeia/commit/279af36400578f2e368235878a03beb8182942b7
+437,1,1,David Hill,2017-10-18 16:49:30,https://github.com/decred/politeia/commit/d937594a570187f1fbb8066f688f1b5491a5fba7
+438,1,1,Sean Durkin,2017-10-18 16:26:01,https://github.com/decred/politeia/commit/331b60057a097ac51ad2b058dea1e4300c467490
+439,1,1,Sean Durkin,2017-10-18 16:25:37,https://github.com/decred/politeia/commit/b43110202ebff1015354d4494df83c6996dbb6ee
+440,1,1,Marco Peereboom,2017-10-18 16:22:38,https://github.com/decred/politeia/commit/eb827bfcadfe5bbd8e4d8683ace343e358bf4a9d
+441,1,1,David Hill,2017-10-18 13:32:26,https://github.com/decred/politeia/commit/0ff7a1c923e819ac26e49e5888b0444e2964ad8a
+442,1,1,David Hill,2017-10-17 17:35:35,https://github.com/decred/politeia/commit/32b15523d7af4c966e4ab5853dbd82b1c76818a0
+443,1,1,Sean Durkin,2017-10-17 16:37:49,https://github.com/decred/politeia/commit/62886647d84cc9cec6641a1543b21d7fb2e64227
+444,1,1,Sean Durkin,2017-10-17 15:41:29,https://github.com/decred/politeia/commit/947d0c1a820ee713c8f21d8b9c4ed971d8b9514d
+445,1,1,David Hill,2017-10-17 14:49:05,https://github.com/decred/politeia/commit/72ab785594fa6924d636bd56c05cb3fea8ff8a82
+446,1,1,David Hill,2017-10-16 19:36:45,https://github.com/decred/politeia/commit/cb0680e7ec845ae4ba10c72fb45acd80c3379372
+447,1,1,Sean Durkin,2017-10-16 15:42:11,https://github.com/decred/politeia/commit/76b51b778348dabe8b89f72322d3404ea1e95e97
+448,1,1,Marco Peereboom,2017-10-16 12:47:59,https://github.com/decred/politeia/commit/44750e7bf1b3c87fa45e7058b0e885d2a5dc7869
+449,1,1,Sean Durkin,2017-10-05 19:22:34,https://github.com/decred/politeia/commit/fec5892fb2b3511eb40459d2efa65b54517fa231
+450,1,1,David Hill,2017-10-05 18:15:06,https://github.com/decred/politeia/commit/5246f091ae4662c0d490ad83964466b071c78626
+451,1,1,Marco Peereboom,2017-10-05 15:25:40,https://github.com/decred/politeia/commit/a436b56736874f844d21c975bdd03f326830f563
+452,1,1,Marco Peereboom,2017-10-05 15:25:04,https://github.com/decred/politeia/commit/a2766752dd7a61a71a93033c85725a1905070c85
+453,1,1,Marco Peereboom,2017-10-04 15:59:51,https://github.com/decred/politeia/commit/ea0228d216ca3c99d5aac77a511b6615ab6995be
+454,1,1,Marco Peereboom,2017-10-04 15:47:09,https://github.com/decred/politeia/commit/fd8c2ec474b2f20d9bcd7077936b49b9ad1389a8
+455,1,1,Marco Peereboom,2017-10-04 15:16:53,https://github.com/decred/politeia/commit/e7cb59c89e648c8e6b11e6fc875c8d38f91f7eba
+456,1,1,Marco Peereboom,2017-10-04 14:44:35,https://github.com/decred/politeia/commit/6947d0c69ac3f417417a4aca197fdab67872fdc3
+457,1,1,Sean Durkin,2017-10-03 13:23:43,https://github.com/decred/politeia/commit/9f16c7ac883c18e05e445908ec03c4712043c829
+458,1,1,Sean Durkin,2017-09-29 18:12:14,https://github.com/decred/politeia/commit/b2bd449d25463523248e2e46d18a056311b01463
+459,1,1,Sean Durkin,2017-09-29 18:10:40,https://github.com/decred/politeia/commit/814e46d0400835e54cf26a62902d61b0aaa59733
+460,1,1,David Hill,2017-09-27 20:03:54,https://github.com/decred/politeia/commit/35ab0667c396bd09fe0ae10fa7f2102132be75d4
+461,1,1,Sean Durkin,2017-09-27 14:20:51,https://github.com/decred/politeia/commit/6fa02d5635212b818b2aa8065bc94ef17b557b48
+462,1,1,Sean Durkin,2017-09-26 15:29:51,https://github.com/decred/politeia/commit/d161aecadad09a7e0aa9703868ff6bf364875d6f
+463,1,1,Sean Durkin,2017-09-25 20:50:07,https://github.com/decred/politeia/commit/7d47e688c4664196b82be2b59ff16ef5c9199be4
+464,1,1,Marco Peereboom,2017-09-19 19:03:12,https://github.com/decred/politeia/commit/ae1fe680ca04840ccc347ca18b9674e8284efa41
+465,1,1,Sean Durkin,2017-09-19 13:35:59,https://github.com/decred/politeia/commit/a0de30caec4c3f63af9add9b85758fe49908cb8e
+466,1,1,Marco Peereboom,2017-09-18 17:29:26,https://github.com/decred/politeia/commit/15a70f20a941106fa3633cfb12b4c1d232d6d552
+467,1,1,Marco Peereboom,2017-09-18 17:27:03,https://github.com/decred/politeia/commit/eb07c611fc287f1e7ffa03b090f7afe3012ac5da
+468,1,1,Sean Durkin,2017-09-18 12:50:37,https://github.com/decred/politeia/commit/3adfd983b444f6d2cf33ca3cdbd880636c230f16
+469,1,1,Marco Peereboom,2017-09-15 16:33:52,https://github.com/decred/politeia/commit/675df7983a48f27c6bc0d5e7640ebc62e4f79b67
+470,1,1,Marco Peereboom,2017-09-15 12:58:14,https://github.com/decred/politeia/commit/9f686471088b8ebbfaacf048e81905337e30f348
+471,1,1,Marco Peereboom,2017-09-14 19:29:34,https://github.com/decred/politeia/commit/7f9af9e0b8017aec10f59bfcef402e31cc665802
+472,1,1,Sean Durkin,2017-09-14 19:27:36,https://github.com/decred/politeia/commit/5be8ed66ac3f092ebea245f6eb10fdff6b75f6e4
+473,1,1,Marco Peereboom,2017-09-14 19:06:34,https://github.com/decred/politeia/commit/f339cf4a31f02fe2f8d9a9eec48e3321afc7c3dd
+474,1,1,Marco Peereboom,2017-09-14 01:58:16,https://github.com/decred/politeia/commit/9263e6e47cd8f649d921b1b1b0e4a6251e4c60c8
+475,1,1,Marco Peereboom,2017-09-13 22:01:21,https://github.com/decred/politeia/commit/04608f8b7ea61df52155538da71376081a3bf0c0
+476,1,1,Marco Peereboom,2017-09-13 21:10:19,https://github.com/decred/politeia/commit/bbd1272cd657bb9d5222b24272e3fb5896a26afd
+477,1,1,Sean Durkin,2017-09-13 11:32:16,https://github.com/decred/politeia/commit/f7f58c1cf7a280a1d33bb56a3945d396b974b18a
+478,1,1,Sean Durkin,2017-09-12 13:13:31,https://github.com/decred/politeia/commit/ce36cb5a44deaf2a675be650cd98450704646315
+479,1,1,Marco Peereboom,2017-09-08 14:26:31,https://github.com/decred/politeia/commit/2839c176392a864e1cb4d146939122571973aadc
+480,1,1,Sean Durkin,2017-09-07 12:55:49,https://github.com/decred/politeia/commit/03c1bf5a8d6c58a495f157d1cb194fd1aa4a3ffb
+481,1,1,Marco Peereboom,2017-09-06 22:36:53,https://github.com/decred/politeia/commit/3a838651dd775651f21c6c6104fc5052280cdd63
+482,1,1,Marco Peereboom,2017-09-06 20:51:34,https://github.com/decred/politeia/commit/c01973d8de5f350be6635361187f307e229bfd52
+483,1,1,Marco Peereboom,2017-08-31 15:45:06,https://github.com/decred/politeia/commit/72b951c28debf532679eb225e67a8790b74cab8d
+484,1,1,Marco Peereboom,2017-08-31 13:01:13,https://github.com/decred/politeia/commit/c5c052f3371ef1b8561eace41299c7fcd4e2d729
+485,1,1,Marco Peereboom,2017-08-29 18:26:40,https://github.com/decred/politeia/commit/7be2b9dd24d68b0c2e7b3dd7a89ee33b1dd10200
+486,1,1,Marco Peereboom,2017-08-29 17:51:38,https://github.com/decred/politeia/commit/f73c0a569c21aec6d5afaa48919fc039a7e0b474
+487,1,1,Marco Peereboom,2017-08-29 13:37:19,https://github.com/decred/politeia/commit/ef12a8a7676f6cb5498aeda91c7d61f876486587
+488,1,1,Sean Durkin,2017-08-29 13:35:16,https://github.com/decred/politeia/commit/7756d103d047b8b6c10a42ab40ecfdc031c0c360
+489,1,1,Marco Peereboom,2017-08-29 13:01:33,https://github.com/decred/politeia/commit/0c44edf0c1e2f5523d1a8e340f3cd8cea0701fee
+490,1,1,Marco Peereboom,2017-08-28 20:50:09,https://github.com/decred/politeia/commit/f721a76268a8bf4d91d12396c4fba6fc853b8ff4
+491,1,1,Marco Peereboom,2017-08-25 21:20:44,https://github.com/decred/politeia/commit/4ad3a71064a77896d21952adac3fd5dd10afd6fc
+492,1,1,Marco Peereboom,2017-08-25 15:37:45,https://github.com/decred/politeia/commit/19dbf27bd1f32d07c8c82a49726a101efb3935b3
+493,1,1,Marco Peereboom,2017-08-24 21:21:58,https://github.com/decred/politeia/commit/08b6c75a5a7baf94621b7834cf25c57d0d3dcf96
+494,1,1,Marco Peereboom,2017-08-24 21:20:47,https://github.com/decred/politeia/commit/3909e28c3bd381f21879507ec57914e79c391e49
+495,1,1,Marco Peereboom,2017-08-24 20:57:53,https://github.com/decred/politeia/commit/054b08774a56c21757769f0225a6af09a86273fc
+496,3,1,alexlyp,2019-03-28 17:41:51,https://github.com/decred/politeia/pull/756
+497,3,1,lukebp,2019-03-27 14:34:26,https://github.com/decred/politeia/pull/755
+498,3,1,chappjc,2019-03-26 18:29:00,https://github.com/decred/politeia/pull/754
+499,3,1,alexlyp,2019-03-25 21:22:55,https://github.com/decred/politeia/pull/753
+500,3,1,dajohi,2019-03-25 18:40:06,https://github.com/decred/politeia/pull/752
+501,3,1,chappjc,2019-03-25 16:03:48,https://github.com/decred/politeia/pull/750
+502,3,1,dajohi,2019-03-25 15:29:30,https://github.com/decred/politeia/pull/749
+503,3,1,jrick,2019-03-23 18:37:56,https://github.com/decred/politeia/pull/748
+504,3,1,lukebp,2019-03-22 12:34:07,https://github.com/decred/politeia/pull/745
+505,3,1,s-ben,2019-03-22 05:15:32,https://github.com/decred/politeia/pull/744
+506,3,1,s-ben,2019-03-22 00:17:50,https://github.com/decred/politeia/pull/743
+507,3,1,lukebp,2019-03-21 17:53:31,https://github.com/decred/politeia/pull/742
+508,3,1,lukebp,2019-03-21 16:44:17,https://github.com/decred/politeia/pull/741
+509,3,1,lukebp,2019-03-21 15:10:12,https://github.com/decred/politeia/pull/740
+510,3,1,alexlyp,2019-03-19 20:19:09,https://github.com/decred/politeia/pull/735
+511,3,1,alexlyp,2019-03-19 18:01:34,https://github.com/decred/politeia/pull/734
+512,3,1,alexlyp,2019-03-19 17:54:13,https://github.com/decred/politeia/pull/733
+513,3,1,lukebp,2019-03-19 16:53:08,https://github.com/decred/politeia/pull/732
+514,3,1,thi4go,2019-03-19 14:01:31,https://github.com/decred/politeia/pull/731
+515,3,1,lukebp,2019-03-19 12:35:20,https://github.com/decred/politeia/pull/730
+516,3,1,s-ben,2019-03-15 20:17:02,https://github.com/decred/politeia/pull/728
+517,3,1,lukebp,2019-03-15 17:12:51,https://github.com/decred/politeia/pull/727
+518,3,1,marcopeereboom,2019-03-14 15:17:00,https://github.com/decred/politeia/pull/726
+519,3,1,orthomind,2019-03-14 06:38:21,https://github.com/decred/politeia/pull/725
+520,3,1,marcopeereboom,2019-03-13 14:54:02,https://github.com/decred/politeia/pull/724
+521,3,1,marcopeereboom,2019-03-11 17:17:21,https://github.com/decred/politeia/pull/722
+522,3,1,lukebp,2019-03-11 15:42:54,https://github.com/decred/politeia/pull/721
+523,3,1,fernandoabolafio,2019-03-08 14:04:34,https://github.com/decred/politeia/pull/719
+524,3,1,alexlyp,2019-03-04 16:52:01,https://github.com/decred/politeia/pull/715
+525,3,1,davecgh,2019-03-04 10:23:20,https://github.com/decred/politeia/pull/714
+526,3,1,lukebp,2019-03-01 16:06:50,https://github.com/decred/politeia/pull/711
+527,3,1,alexlyp,2019-02-28 22:54:31,https://github.com/decred/politeia/pull/710
+528,3,1,thi4go,2019-02-27 14:16:09,https://github.com/decred/politeia/pull/709
+529,3,1,dajohi,2019-02-26 21:13:57,https://github.com/decred/politeia/pull/708
+530,3,1,lukebp,2019-02-26 16:36:31,https://github.com/decred/politeia/pull/707
+531,3,1,alexlyp,2019-02-25 19:45:15,https://github.com/decred/politeia/pull/705
+532,3,1,dajohi,2019-02-22 20:00:09,https://github.com/decred/politeia/pull/703
+533,3,1,dajohi,2019-02-22 18:29:12,https://github.com/decred/politeia/pull/702
+534,3,1,marcopeereboom,2019-02-21 19:59:27,https://github.com/decred/politeia/pull/701
+535,3,1,camus-code,2019-02-19 20:08:50,https://github.com/decred/politeia/pull/700
+536,3,1,lukebp,2019-02-15 19:20:49,https://github.com/decred/politeia/pull/699
+537,3,1,lukebp,2019-02-15 17:50:54,https://github.com/decred/politeia/pull/697
+538,3,1,lukebp,2019-02-14 19:02:41,https://github.com/decred/politeia/pull/696
+539,3,1,lukebp,2019-02-13 17:57:01,https://github.com/decred/politeia/pull/694
+540,3,1,lukebp,2019-02-13 14:33:10,https://github.com/decred/politeia/pull/693
+541,3,1,camus-code,2019-02-12 19:33:58,https://github.com/decred/politeia/pull/690
+542,3,1,fernandoabolafio,2019-02-12 11:57:22,https://github.com/decred/politeia/pull/689
+543,3,1,dajohi,2019-02-11 16:57:30,https://github.com/decred/politeia/pull/688
+544,3,1,dajohi,2019-02-09 13:00:25,https://github.com/decred/politeia/pull/687
+545,3,1,dajohi,2019-02-07 19:21:25,https://github.com/decred/politeia/pull/686
+546,3,1,lukebp,2019-02-03 18:29:07,https://github.com/decred/politeia/pull/684
+547,3,1,s-ben,2019-02-01 04:11:36,https://github.com/decred/politeia/pull/683
+548,3,1,s-ben,2019-02-01 01:59:31,https://github.com/decred/politeia/pull/682
+549,3,1,dajohi,2019-01-30 17:10:34,https://github.com/decred/politeia/pull/681
+550,3,1,thi4go,2019-01-28 14:15:05,https://github.com/decred/politeia/pull/680
+551,3,1,s-ben,2019-01-26 01:27:52,https://github.com/decred/politeia/pull/679
+552,3,1,s-ben,2019-01-24 22:31:37,https://github.com/decred/politeia/pull/677
+553,3,1,dajohi,2019-01-24 01:31:55,https://github.com/decred/politeia/pull/675
+554,3,1,camus-code,2019-01-23 19:20:56,https://github.com/decred/politeia/pull/674
+555,3,1,camus-code,2019-01-17 17:45:20,https://github.com/decred/politeia/pull/671
+556,3,1,marcopeereboom,2019-01-16 16:14:28,https://github.com/decred/politeia/pull/668
+557,3,1,orthomind,2019-01-12 13:00:47,https://github.com/decred/politeia/pull/667
+558,3,1,victorgcramos,2019-01-08 15:18:35,https://github.com/decred/politeia/pull/663
+559,3,1,lukebp,2019-01-07 13:35:43,https://github.com/decred/politeia/pull/660
+560,3,1,dajohi,2019-01-02 14:48:10,https://github.com/decred/politeia/pull/659
+561,3,1,EvertonMelo,2019-01-01 02:59:26,https://github.com/decred/politeia/pull/658
+562,3,1,fernandoabolafio,2018-12-26 16:07:22,https://github.com/decred/politeia/pull/655
+563,3,1,thi4go,2018-12-22 18:06:02,https://github.com/decred/politeia/pull/649
+564,3,1,lukebp,2018-12-21 16:06:49,https://github.com/decred/politeia/pull/648
+565,3,1,lukebp,2018-12-19 12:26:26,https://github.com/decred/politeia/pull/646
+566,3,1,lukebp,2018-12-19 12:02:28,https://github.com/decred/politeia/pull/645
+567,3,1,thi4go,2018-12-18 11:57:57,https://github.com/decred/politeia/pull/644
+568,3,1,tpkeeper,2018-12-18 08:18:59,https://github.com/decred/politeia/pull/643
+569,3,1,thi4go,2018-12-11 22:27:36,https://github.com/decred/politeia/pull/641
+570,3,1,s-ben,2018-12-08 05:08:54,https://github.com/decred/politeia/pull/640
+571,3,1,davecgh,2018-12-07 18:38:08,https://github.com/decred/politeia/pull/639
+572,3,1,marcopeereboom,2018-12-07 15:56:28,https://github.com/decred/politeia/pull/638
+573,3,1,lukebp,2018-12-07 14:53:15,https://github.com/decred/politeia/pull/637
+574,3,1,dajohi,2018-12-06 21:07:20,https://github.com/decred/politeia/pull/636
+575,3,1,thi4go,2018-12-06 14:34:44,https://github.com/decred/politeia/pull/635
+576,3,1,camus-code,2018-12-05 18:03:11,https://github.com/decred/politeia/pull/634
+577,3,1,lukebp,2018-12-03 16:39:55,https://github.com/decred/politeia/pull/633
+578,3,1,lukebp,2018-12-03 16:17:34,https://github.com/decred/politeia/pull/632
+579,3,1,camus-code,2018-12-03 15:06:19,https://github.com/decred/politeia/pull/631
+580,3,1,s-ben,2018-12-02 07:13:38,https://github.com/decred/politeia/pull/628
+581,3,1,lukebp,2018-11-30 12:12:23,https://github.com/decred/politeia/pull/626
+582,3,1,s-ben,2018-11-29 22:55:25,https://github.com/decred/politeia/pull/625
+583,3,1,fernandoabolafio,2018-11-29 19:45:44,https://github.com/decred/politeia/pull/624
+584,3,1,dajohi,2018-11-29 17:00:39,https://github.com/decred/politeia/pull/623
+585,3,1,lukebp,2018-11-28 18:20:24,https://github.com/decred/politeia/pull/620
+586,3,1,thi4go,2018-11-26 12:00:44,https://github.com/decred/politeia/pull/617
+587,3,1,sndurkin,2018-11-26 02:29:10,https://github.com/decred/politeia/pull/616
+588,3,1,victorgcramos,2018-11-24 18:02:30,https://github.com/decred/politeia/pull/615
+589,3,1,fernandoabolafio,2018-11-21 12:55:55,https://github.com/decred/politeia/pull/613
+590,3,1,fernandoabolafio,2018-11-19 19:08:10,https://github.com/decred/politeia/pull/610
+591,3,1,lukebp,2018-11-19 17:50:32,https://github.com/decred/politeia/pull/609
+592,3,1,victorgcramos,2018-11-18 02:37:00,https://github.com/decred/politeia/pull/606
+593,3,1,lukebp,2018-11-15 21:56:46,https://github.com/decred/politeia/pull/604
+594,3,1,dajohi,2018-11-14 16:05:56,https://github.com/decred/politeia/pull/602
+595,3,1,fernandoabolafio,2018-11-14 13:12:46,https://github.com/decred/politeia/pull/600
+696,3,1,lukebp,2018-11-13 23:48:32,https://github.com/decred/politeia/pull/599
+697,3,1,tiagoalvesdulce,2018-11-13 17:48:47,https://github.com/decred/politeia/pull/598
+698,3,1,thi4go,2018-11-13 12:52:56,https://github.com/decred/politeia/pull/595
+699,3,1,fernandoabolafio,2018-11-12 13:11:00,https://github.com/decred/politeia/pull/594
+700,3,1,lukebp,2018-11-09 18:30:09,https://github.com/decred/politeia/pull/589
+701,3,1,lukebp,2018-11-09 12:54:06,https://github.com/decred/politeia/pull/587
+702,3,1,lukebp,2018-11-09 12:51:16,https://github.com/decred/politeia/pull/586
+703,3,1,degeri,2018-11-08 07:34:15,https://github.com/decred/politeia/pull/584
+704,3,1,fernandoabolafio,2018-11-05 23:52:40,https://github.com/decred/politeia/pull/581
+705,3,1,lukebp,2018-11-02 23:54:02,https://github.com/decred/politeia/pull/579
+706,3,1,sndurkin,2018-11-02 04:26:07,https://github.com/decred/politeia/pull/577
+707,3,1,lukebp,2018-11-01 16:39:20,https://github.com/decred/politeia/pull/574
+708,3,1,dajohi,2018-11-01 02:23:22,https://github.com/decred/politeia/pull/572
+709,3,1,marcopeereboom,2018-10-31 18:45:16,https://github.com/decred/politeia/pull/571
+710,3,1,fernandoabolafio,2018-10-30 20:30:58,https://github.com/decred/politeia/pull/568
+711,3,1,dajohi,2018-10-29 20:07:28,https://github.com/decred/politeia/pull/566
+712,3,1,marcopeereboom,2018-10-25 19:14:34,https://github.com/decred/politeia/pull/559
+713,3,1,dajohi,2018-10-23 19:16:56,https://github.com/decred/politeia/pull/557
+714,3,1,sndurkin,2018-10-23 04:13:24,https://github.com/decred/politeia/pull/553
+715,3,1,lukebp,2018-10-22 20:42:41,https://github.com/decred/politeia/pull/552
+716,3,1,fernandoabolafio,2018-10-22 17:46:05,https://github.com/decred/politeia/pull/551
+717,3,1,lukebp,2018-10-22 14:33:35,https://github.com/decred/politeia/pull/550
+718,3,1,sndurkin,2018-10-21 15:38:29,https://github.com/decred/politeia/pull/549
+719,3,1,lukebp,2018-10-19 16:23:17,https://github.com/decred/politeia/pull/548
+720,3,1,sndurkin,2018-10-18 14:39:20,https://github.com/decred/politeia/pull/542
+721,3,1,sndurkin,2018-10-18 02:09:32,https://github.com/decred/politeia/pull/541
+722,3,1,marcopeereboom,2018-10-17 20:38:42,https://github.com/decred/politeia/pull/540
+723,3,1,sndurkin,2018-10-17 17:00:31,https://github.com/decred/politeia/pull/536
+724,3,1,sndurkin,2018-10-17 03:52:12,https://github.com/decred/politeia/pull/533
+725,3,1,sndurkin,2018-10-17 03:38:03,https://github.com/decred/politeia/pull/532
+726,3,1,marcopeereboom,2018-10-16 19:41:04,https://github.com/decred/politeia/pull/531
+727,3,1,fernandoabolafio,2018-10-16 18:36:46,https://github.com/decred/politeia/pull/530
+728,3,1,sndurkin,2018-10-16 16:21:00,https://github.com/decred/politeia/pull/529
+729,3,1,lukebp,2018-10-16 03:19:09,https://github.com/decred/politeia/pull/526
+730,3,1,marcopeereboom,2018-10-15 21:06:12,https://github.com/decred/politeia/pull/523
+731,3,1,marcopeereboom,2018-10-15 19:56:48,https://github.com/decred/politeia/pull/521
+732,3,1,fernandoabolafio,2018-10-15 19:31:06,https://github.com/decred/politeia/pull/520
+733,3,1,marcopeereboom,2018-10-15 17:37:01,https://github.com/decred/politeia/pull/519
+734,3,1,lukebp,2018-10-15 15:03:58,https://github.com/decred/politeia/pull/518
+735,3,1,fernandoabolafio,2018-10-15 14:31:05,https://github.com/decred/politeia/pull/517
+736,3,1,marcopeereboom,2018-10-12 17:41:35,https://github.com/decred/politeia/pull/516
+737,3,1,tiagoalvesdulce,2018-10-10 23:33:02,https://github.com/decred/politeia/pull/515
+738,3,1,marcopeereboom,2018-10-09 14:46:16,https://github.com/decred/politeia/pull/512
+739,3,1,lukebp,2018-10-08 13:26:48,https://github.com/decred/politeia/pull/510
+740,3,1,marcopeereboom,2018-10-05 20:07:07,https://github.com/decred/politeia/pull/506
+741,3,1,fernandoabolafio,2018-10-04 18:03:58,https://github.com/decred/politeia/pull/504
+742,3,1,lukebp,2018-10-04 17:40:02,https://github.com/decred/politeia/pull/503
+743,3,1,dajohi,2018-10-04 17:25:34,https://github.com/decred/politeia/pull/502
+744,3,1,tiagoalvesdulce,2018-10-03 13:18:25,https://github.com/decred/politeia/pull/497
+745,3,1,lukebp,2018-10-02 19:31:03,https://github.com/decred/politeia/pull/496
+746,3,1,fernandoabolafio,2018-10-02 13:26:10,https://github.com/decred/politeia/pull/495
+747,3,1,wallclockbuilder,2018-10-01 22:10:45,https://github.com/decred/politeia/pull/494
+748,3,1,marcopeereboom,2018-10-01 15:19:11,https://github.com/decred/politeia/pull/493
+749,3,1,fernandoabolafio,2018-09-28 21:33:57,https://github.com/decred/politeia/pull/492
+750,3,1,fernandoabolafio,2018-09-27 22:03:29,https://github.com/decred/politeia/pull/491
+751,3,1,marcopeereboom,2018-09-26 21:45:58,https://github.com/decred/politeia/pull/489
+752,3,1,vctt94,2018-09-26 20:01:22,https://github.com/decred/politeia/pull/488
+753,3,1,marcopeereboom,2018-09-26 19:11:32,https://github.com/decred/politeia/pull/487
+754,3,1,lukebp,2018-09-26 17:06:40,https://github.com/decred/politeia/pull/485
+755,3,1,thi4go,2018-09-25 21:16:24,https://github.com/decred/politeia/pull/484
+756,3,1,lukebp,2018-09-25 15:18:30,https://github.com/decred/politeia/pull/483
+757,3,1,fernandoabolafio,2018-09-24 20:15:29,https://github.com/decred/politeia/pull/482
+758,3,1,lukebp,2018-09-24 15:44:47,https://github.com/decred/politeia/pull/480
+759,3,1,dajohi,2018-09-21 17:51:07,https://github.com/decred/politeia/pull/477
+760,3,1,lukebp,2018-09-21 13:59:47,https://github.com/decred/politeia/pull/476
+761,3,1,lukebp,2018-09-20 14:22:56,https://github.com/decred/politeia/pull/475
+762,3,1,lukebp,2018-09-19 20:07:16,https://github.com/decred/politeia/pull/473
+763,3,1,lukebp,2018-09-18 21:03:51,https://github.com/decred/politeia/pull/472
+764,3,1,dajohi,2018-09-18 20:40:05,https://github.com/decred/politeia/pull/471
+765,3,1,lukebp,2018-09-18 15:54:15,https://github.com/decred/politeia/pull/470
+766,3,1,marcopeereboom,2018-09-13 16:29:01,https://github.com/decred/politeia/pull/469
+767,3,1,thi4go,2018-09-12 23:02:02,https://github.com/decred/politeia/pull/468
+768,3,1,s-ben,2018-09-12 18:21:06,https://github.com/decred/politeia/pull/467
+769,3,1,lukebp,2018-09-11 19:53:58,https://github.com/decred/politeia/pull/466
+770,3,1,fernandoabolafio,2018-09-11 17:49:21,https://github.com/decred/politeia/pull/465
+771,3,1,fernandoabolafio,2018-09-11 15:07:54,https://github.com/decred/politeia/pull/464
+772,3,1,lukebp,2018-09-10 14:18:05,https://github.com/decred/politeia/pull/460
+773,3,1,marcopeereboom,2018-09-07 18:58:53,https://github.com/decred/politeia/pull/458
+774,3,1,tiagoalvesdulce,2018-09-07 15:57:21,https://github.com/decred/politeia/pull/457
+775,3,1,lukebp,2018-09-06 14:14:54,https://github.com/decred/politeia/pull/455
+776,3,1,fernandoabolafio,2018-09-05 19:35:04,https://github.com/decred/politeia/pull/452
+777,3,1,lukebp,2018-09-05 17:22:06,https://github.com/decred/politeia/pull/451
+778,3,1,lukebp,2018-09-05 12:10:11,https://github.com/decred/politeia/pull/443
+779,3,1,lukebp,2018-09-04 23:32:46,https://github.com/decred/politeia/pull/442
+780,3,1,tiagoalvesdulce,2018-09-04 18:04:50,https://github.com/decred/politeia/pull/440
+781,3,1,fernandoabolafio,2018-09-04 13:44:04,https://github.com/decred/politeia/pull/439
+782,3,1,fernandoabolafio,2018-09-03 22:42:14,https://github.com/decred/politeia/pull/438
+783,3,1,fernandoabolafio,2018-08-31 20:14:29,https://github.com/decred/politeia/pull/437
+784,3,1,dajohi,2018-08-31 13:54:02,https://github.com/decred/politeia/pull/436
+785,3,1,fernandoabolafio,2018-08-31 13:15:16,https://github.com/decred/politeia/pull/435
+786,3,1,dajohi,2018-08-30 15:39:09,https://github.com/decred/politeia/pull/434
+787,3,1,marcopeereboom,2018-08-30 14:26:26,https://github.com/decred/politeia/pull/433
+788,3,1,lukebp,2018-08-30 14:20:54,https://github.com/decred/politeia/pull/432
+789,3,1,dajohi,2018-08-29 20:13:25,https://github.com/decred/politeia/pull/431
+790,3,1,vctt94,2018-08-29 18:46:18,https://github.com/decred/politeia/pull/430
+791,3,1,fernandoabolafio,2018-08-29 16:10:35,https://github.com/decred/politeia/pull/429
+792,3,1,fernandoabolafio,2018-08-29 14:42:38,https://github.com/decred/politeia/pull/428
+793,3,1,fernandoabolafio,2018-08-24 17:20:20,https://github.com/decred/politeia/pull/425
+794,3,1,fernandoabolafio,2018-08-15 22:27:55,https://github.com/decred/politeia/pull/424
+795,3,1,lukebp,2018-08-13 20:38:07,https://github.com/decred/politeia/pull/423
+796,3,1,lukebp,2018-08-10 21:18:41,https://github.com/decred/politeia/pull/422
+797,3,1,marcopeereboom,2018-08-10 17:03:35,https://github.com/decred/politeia/pull/420
+798,3,1,sndurkin,2018-08-09 03:21:22,https://github.com/decred/politeia/pull/419
+799,3,1,sndurkin,2018-08-08 21:17:44,https://github.com/decred/politeia/pull/418
+800,3,1,dajohi,2018-08-08 17:54:47,https://github.com/decred/politeia/pull/417
+801,3,1,fernandoabolafio,2018-08-06 20:28:29,https://github.com/decred/politeia/pull/415
+802,3,1,sndurkin,2018-08-02 14:12:00,https://github.com/decred/politeia/pull/413
+803,3,1,sndurkin,2018-08-02 03:56:39,https://github.com/decred/politeia/pull/412
+804,3,1,sndurkin,2018-08-01 16:36:26,https://github.com/decred/politeia/pull/411
+805,3,1,sndurkin,2018-08-01 05:17:40,https://github.com/decred/politeia/pull/410
+806,3,1,lukebp,2018-08-01 00:49:28,https://github.com/decred/politeia/pull/409
+807,3,1,lukebp,2018-07-30 12:45:05,https://github.com/decred/politeia/pull/408
+808,3,1,lukebp,2018-07-25 17:37:21,https://github.com/decred/politeia/pull/406
+809,3,1,vctt94,2018-07-25 13:41:05,https://github.com/decred/politeia/pull/404
+810,3,1,hsanjuan,2018-07-23 22:50:12,https://github.com/decred/politeia/pull/401
+811,3,1,fernandoabolafio,2018-07-23 16:26:38,https://github.com/decred/politeia/pull/400
+812,3,1,lukebp,2018-07-21 18:52:30,https://github.com/decred/politeia/pull/398
+813,3,1,fernandoabolafio,2018-07-20 20:32:27,https://github.com/decred/politeia/pull/395
+814,3,1,vctt94,2018-07-19 15:37:38,https://github.com/decred/politeia/pull/394
+815,3,1,fernandoabolafio,2018-07-18 21:43:30,https://github.com/decred/politeia/pull/393
+816,3,1,sndurkin,2018-07-18 04:45:55,https://github.com/decred/politeia/pull/392
+817,3,1,lukebp,2018-07-17 23:43:12,https://github.com/decred/politeia/pull/391
+818,3,1,sndurkin,2018-07-17 18:27:35,https://github.com/decred/politeia/pull/390
+819,3,1,sndurkin,2018-07-16 03:30:54,https://github.com/decred/politeia/pull/389
+820,3,1,marcopeereboom,2018-07-13 12:01:03,https://github.com/decred/politeia/pull/387
+821,3,1,fernandoabolafio,2018-07-13 10:51:40,https://github.com/decred/politeia/pull/386
+822,3,1,sndurkin,2018-07-13 03:01:46,https://github.com/decred/politeia/pull/385
+823,3,1,vctt94,2018-07-12 15:50:00,https://github.com/decred/politeia/pull/382
+824,3,1,dajohi,2018-07-11 20:09:29,https://github.com/decred/politeia/pull/378
+825,3,1,sndurkin,2018-07-06 22:58:27,https://github.com/decred/politeia/pull/375
+826,3,1,vctt94,2018-07-06 15:48:17,https://github.com/decred/politeia/pull/374
+827,3,1,sndurkin,2018-07-06 13:19:58,https://github.com/decred/politeia/pull/373
+828,3,1,tiagoalvesdulce,2018-07-03 19:22:04,https://github.com/decred/politeia/pull/371
+829,3,1,fernandoabolafio,2018-07-03 18:52:19,https://github.com/decred/politeia/pull/370
+830,3,1,marcopeereboom,2018-07-03 13:02:12,https://github.com/decred/politeia/pull/367
+831,3,1,marcopeereboom,2018-07-03 10:44:59,https://github.com/decred/politeia/pull/365
+832,3,1,tiagoalvesdulce,2018-07-02 20:25:27,https://github.com/decred/politeia/pull/363
+833,3,1,rrecuero,2018-07-02 00:32:52,https://github.com/decred/politeia/pull/361
+834,3,1,sndurkin,2018-06-30 02:32:16,https://github.com/decred/politeia/pull/360
+835,3,1,sndurkin,2018-06-28 14:05:58,https://github.com/decred/politeia/pull/359
+836,3,1,tiagoalvesdulce,2018-06-25 19:24:54,https://github.com/decred/politeia/pull/352
+837,3,1,sndurkin,2018-06-25 15:00:38,https://github.com/decred/politeia/pull/351
+838,3,1,RichardRed0x,2018-06-22 14:31:46,https://github.com/decred/politeia/pull/348
+839,3,1,sndurkin,2018-06-22 03:57:51,https://github.com/decred/politeia/pull/345
+840,3,1,lukebp,2018-06-21 21:51:51,https://github.com/decred/politeia/pull/344
+841,3,1,sndurkin,2018-06-21 16:32:49,https://github.com/decred/politeia/pull/342
+842,3,1,fernandoabolafio,2018-06-21 16:00:42,https://github.com/decred/politeia/pull/341
+843,3,1,sndurkin,2018-06-21 04:41:31,https://github.com/decred/politeia/pull/338
+844,3,1,chappjc,2018-06-20 23:53:33,https://github.com/decred/politeia/pull/337
+845,3,1,fernandoabolafio,2018-06-20 20:30:24,https://github.com/decred/politeia/pull/336
+846,3,1,fernandoabolafio,2018-06-20 13:44:59,https://github.com/decred/politeia/pull/334
+847,3,1,marcopeereboom,2018-06-20 13:12:21,https://github.com/decred/politeia/pull/333
+848,3,1,fernandoabolafio,2018-06-18 21:51:59,https://github.com/decred/politeia/pull/331
+849,3,1,marcopeereboom,2018-06-18 11:14:52,https://github.com/decred/politeia/pull/329
+850,3,1,marcopeereboom,2018-06-15 12:57:41,https://github.com/decred/politeia/pull/328
+851,3,1,lukebp,2018-06-15 04:40:43,https://github.com/decred/politeia/pull/327
+852,3,1,tiagoalvesdulce,2018-06-14 17:55:39,https://github.com/decred/politeia/pull/326
+853,3,1,marcopeereboom,2018-06-13 15:37:18,https://github.com/decred/politeia/pull/323
+854,3,1,marcopeereboom,2018-06-13 15:10:41,https://github.com/decred/politeia/pull/322
+855,3,1,decebal,2018-06-13 10:43:57,https://github.com/decred/politeia/pull/321
+856,3,1,fernandoabolafio,2018-06-12 20:21:38,https://github.com/decred/politeia/pull/320
+857,3,1,vctt94,2018-06-11 18:00:32,https://github.com/decred/politeia/pull/318
+858,3,1,marcopeereboom,2018-06-11 11:25:04,https://github.com/decred/politeia/pull/316
+859,3,1,dajohi,2018-06-07 20:03:34,https://github.com/decred/politeia/pull/311
+860,3,1,sndurkin,2018-06-06 04:22:01,https://github.com/decred/politeia/pull/309
+861,3,1,lukebp,2018-06-03 18:21:09,https://github.com/decred/politeia/pull/307
+862,3,1,sndurkin,2018-05-31 04:29:18,https://github.com/decred/politeia/pull/305
+863,3,1,lukebp,2018-05-31 01:08:28,https://github.com/decred/politeia/pull/304
+864,3,1,sndurkin,2018-05-30 21:44:39,https://github.com/decred/politeia/pull/303
+865,3,1,sndurkin,2018-05-30 03:02:42,https://github.com/decred/politeia/pull/302
+866,3,1,sndurkin,2018-05-30 02:18:37,https://github.com/decred/politeia/pull/301
+867,3,1,fernandoabolafio,2018-05-25 19:57:53,https://github.com/decred/politeia/pull/300
+868,3,1,marcopeereboom,2018-05-24 18:39:06,https://github.com/decred/politeia/pull/297
+869,3,1,lukebp,2018-05-24 05:37:54,https://github.com/decred/politeia/pull/294
+870,3,1,lukebp,2018-05-24 05:01:30,https://github.com/decred/politeia/pull/292
+871,3,1,sndurkin,2018-05-23 14:44:44,https://github.com/decred/politeia/pull/290
+872,3,1,lte13,2018-05-21 07:07:56,https://github.com/decred/politeia/pull/289
+873,3,1,fernandoabolafio,2018-05-15 21:21:06,https://github.com/decred/politeia/pull/286
+874,3,1,fernandoabolafio,2018-05-15 14:12:42,https://github.com/decred/politeia/pull/284
+875,3,1,sndurkin,2018-05-15 03:08:07,https://github.com/decred/politeia/pull/283
+876,3,1,sndurkin,2018-05-15 02:59:51,https://github.com/decred/politeia/pull/282
+877,3,1,decebal,2018-05-13 22:51:12,https://github.com/decred/politeia/pull/281
+878,3,1,dajohi,2018-05-10 18:16:35,https://github.com/decred/politeia/pull/279
+879,3,1,sndurkin,2018-05-10 15:33:57,https://github.com/decred/politeia/pull/277
+880,3,1,fernandoabolafio,2018-05-10 13:35:13,https://github.com/decred/politeia/pull/275
+881,3,1,fernandoabolafio,2018-05-09 20:11:37,https://github.com/decred/politeia/pull/274
+882,3,1,EvertonMelo,2018-05-08 13:36:23,https://github.com/decred/politeia/pull/273
+883,3,1,EvertonMelo,2018-05-08 13:31:34,https://github.com/decred/politeia/pull/272
+884,3,1,fernandoabolafio,2018-05-07 18:02:05,https://github.com/decred/politeia/pull/271
+885,3,1,fernandoabolafio,2018-05-07 14:03:26,https://github.com/decred/politeia/pull/269
+886,3,1,lukebp,2018-05-03 04:43:52,https://github.com/decred/politeia/pull/267
+887,3,1,marcopeereboom,2018-04-20 17:51:16,https://github.com/decred/politeia/pull/260
+888,3,1,dajohi,2018-04-19 15:13:51,https://github.com/decred/politeia/pull/258
+889,3,1,dajohi,2018-04-19 14:57:42,https://github.com/decred/politeia/pull/257
+890,3,1,vctt94,2018-04-18 13:42:59,https://github.com/decred/politeia/pull/256
+891,3,1,dajohi,2018-04-17 18:14:33,https://github.com/decred/politeia/pull/255
+892,3,1,marcopeereboom,2018-04-17 16:04:47,https://github.com/decred/politeia/pull/254
+893,3,1,marcopeereboom,2018-04-17 15:41:56,https://github.com/decred/politeia/pull/253
+894,3,1,marcopeereboom,2018-04-17 13:30:02,https://github.com/decred/politeia/pull/251
+895,3,1,marcopeereboom,2018-04-16 20:22:09,https://github.com/decred/politeia/pull/250
+896,3,1,marcopeereboom,2018-04-16 19:40:35,https://github.com/decred/politeia/pull/249
+897,3,1,marcopeereboom,2018-04-16 16:52:32,https://github.com/decred/politeia/pull/248
+898,3,1,dajohi,2018-04-12 18:39:54,https://github.com/decred/politeia/pull/247
+899,3,1,vctt94,2018-04-12 18:26:32,https://github.com/decred/politeia/pull/246
+900,3,1,dajohi,2018-04-11 15:54:52,https://github.com/decred/politeia/pull/245
+901,3,1,marcopeereboom,2018-04-11 14:57:37,https://github.com/decred/politeia/pull/244
+902,3,1,dajohi,2018-04-10 19:37:51,https://github.com/decred/politeia/pull/243
+903,3,1,marcopeereboom,2018-04-09 14:27:05,https://github.com/decred/politeia/pull/242
+904,3,1,vctt94,2018-03-29 20:48:22,https://github.com/decred/politeia/pull/241
+905,3,1,dajohi,2018-03-29 17:17:12,https://github.com/decred/politeia/pull/240
+906,3,1,dajohi,2018-03-29 17:00:51,https://github.com/decred/politeia/pull/239
+907,3,1,sndurkin,2018-03-28 21:12:55,https://github.com/decred/politeia/pull/238
+908,3,1,marcopeereboom,2018-03-13 14:52:36,https://github.com/decred/politeia/pull/236
+909,3,1,sndurkin,2018-02-27 05:06:09,https://github.com/decred/politeia/pull/235
+910,3,1,sudoscript,2018-02-26 00:41:46,https://github.com/decred/politeia/pull/234
+911,3,1,sndurkin,2018-02-22 06:10:22,https://github.com/decred/politeia/pull/232
+912,3,1,sndurkin,2018-02-21 16:53:41,https://github.com/decred/politeia/pull/231
+913,3,1,sndurkin,2018-02-21 16:45:28,https://github.com/decred/politeia/pull/230
+914,3,1,vctt94,2018-02-21 15:50:31,https://github.com/decred/politeia/pull/229
+915,3,1,dajohi,2018-02-15 18:36:24,https://github.com/decred/politeia/pull/228
+916,3,1,sndurkin,2018-02-15 16:27:00,https://github.com/decred/politeia/pull/227
+917,3,1,sndurkin,2018-02-13 14:57:34,https://github.com/decred/politeia/pull/226
+918,3,1,sndurkin,2018-02-06 03:58:28,https://github.com/decred/politeia/pull/224
+919,3,1,AlanL1,2018-01-31 11:03:14,https://github.com/decred/politeia/pull/222
+920,3,1,AlanL1,2018-01-30 16:32:27,https://github.com/decred/politeia/pull/221
+921,3,1,sndurkin,2018-01-23 05:45:53,https://github.com/decred/politeia/pull/219
+922,3,1,sndurkin,2018-01-21 05:51:33,https://github.com/decred/politeia/pull/216
+923,3,1,fernandoabolafio,2018-01-20 14:21:56,https://github.com/decred/politeia/pull/215
+924,3,1,fernandoabolafio,2018-01-18 16:26:07,https://github.com/decred/politeia/pull/214
+925,3,1,marcopeereboom,2018-01-16 16:28:59,https://github.com/decred/politeia/pull/212
+926,3,1,AlanL1,2018-01-15 08:52:40,https://github.com/decred/politeia/pull/206
+927,3,1,sndurkin,2018-01-14 05:55:50,https://github.com/decred/politeia/pull/205
+928,3,1,sndurkin,2018-01-14 03:13:23,https://github.com/decred/politeia/pull/204
+929,3,1,sndurkin,2018-01-13 20:36:36,https://github.com/decred/politeia/pull/203
+930,3,1,sndurkin,2018-01-12 00:02:17,https://github.com/decred/politeia/pull/202
+931,3,1,sndurkin,2018-01-11 14:53:57,https://github.com/decred/politeia/pull/200
+932,3,1,vctt94,2018-01-08 17:36:20,https://github.com/decred/politeia/pull/198
+933,3,1,sndurkin,2017-12-31 07:15:38,https://github.com/decred/politeia/pull/196
+934,3,1,sndurkin,2017-12-30 21:30:07,https://github.com/decred/politeia/pull/195
+935,3,1,marcopeereboom,2017-12-15 20:19:54,https://github.com/decred/politeia/pull/192
+936,3,1,jolan,2017-12-15 19:37:16,https://github.com/decred/politeia/pull/191
+937,3,1,marcopeereboom,2017-12-15 19:15:23,https://github.com/decred/politeia/pull/190
+938,3,1,jolan,2017-12-12 23:00:00,https://github.com/decred/politeia/pull/189
+939,3,1,marcopeereboom,2017-12-07 20:29:37,https://github.com/decred/politeia/pull/187
+940,3,1,marcopeereboom,2017-12-04 17:30:52,https://github.com/decred/politeia/pull/183
+941,3,1,marcopeereboom,2017-12-04 15:03:51,https://github.com/decred/politeia/pull/182
+942,3,1,vctt94,2017-12-04 13:38:20,https://github.com/decred/politeia/pull/181
+943,3,1,dajohi,2017-12-01 19:18:13,https://github.com/decred/politeia/pull/178
+944,3,1,marcopeereboom,2017-12-01 18:58:48,https://github.com/decred/politeia/pull/176
+945,3,1,dajohi,2017-12-01 18:57:51,https://github.com/decred/politeia/pull/175
+946,3,1,marcopeereboom,2017-12-01 18:38:30,https://github.com/decred/politeia/pull/174
+947,3,1,marcopeereboom,2017-12-01 03:54:06,https://github.com/decred/politeia/pull/173
+948,3,1,sndurkin,2017-12-01 03:48:31,https://github.com/decred/politeia/pull/172
+949,3,1,sndurkin,2017-12-01 03:23:20,https://github.com/decred/politeia/pull/171
+950,3,1,sndurkin,2017-12-01 03:19:36,https://github.com/decred/politeia/pull/170
+951,3,1,marcopeereboom,2017-11-30 13:31:06,https://github.com/decred/politeia/pull/165
+952,3,1,sndurkin,2017-11-30 03:09:59,https://github.com/decred/politeia/pull/164
+953,3,1,sndurkin,2017-11-29 19:02:25,https://github.com/decred/politeia/pull/163
+954,3,1,rgeraldes,2017-11-28 23:29:02,https://github.com/decred/politeia/pull/160
+955,3,1,marcopeereboom,2017-11-27 15:34:20,https://github.com/decred/politeia/pull/159
+956,3,1,jolan,2017-11-22 19:13:46,https://github.com/decred/politeia/pull/158
+957,3,1,jolan,2017-11-22 18:30:08,https://github.com/decred/politeia/pull/157
+958,3,1,rgeraldes,2017-11-20 15:47:32,https://github.com/decred/politeia/pull/156
+959,3,1,marcopeereboom,2017-11-20 15:02:18,https://github.com/decred/politeia/pull/154
+960,3,1,jolan,2017-11-17 16:19:04,https://github.com/decred/politeia/pull/152
+961,3,1,rgeraldes,2017-11-16 21:09:36,https://github.com/decred/politeia/pull/151
+962,3,1,vctt94,2017-11-16 18:50:37,https://github.com/decred/politeia/pull/149
+963,3,1,rgeraldes,2017-11-15 23:31:28,https://github.com/decred/politeia/pull/144
+964,3,1,marcopeereboom,2017-11-14 20:13:10,https://github.com/decred/politeia/pull/143
+965,3,1,sndurkin,2017-11-14 17:11:49,https://github.com/decred/politeia/pull/142
+966,3,1,webmasterraj,2017-11-14 03:06:33,https://github.com/decred/politeia/pull/141
+967,3,1,marcopeereboom,2017-11-13 14:45:00,https://github.com/decred/politeia/pull/140
+968,3,1,sndurkin,2017-11-13 04:57:38,https://github.com/decred/politeia/pull/139
+969,3,1,sudoscript,2017-11-13 04:28:53,https://github.com/decred/politeia/pull/138
+970,3,1,sndurkin,2017-11-13 03:25:10,https://github.com/decred/politeia/pull/137
+971,3,1,sndurkin,2017-11-13 02:22:22,https://github.com/decred/politeia/pull/136
+972,3,1,rgeraldes,2017-11-10 04:03:53,https://github.com/decred/politeia/pull/134
+973,3,1,rgeraldes,2017-11-09 22:28:22,https://github.com/decred/politeia/pull/133
+974,3,1,marcopeereboom,2017-11-09 16:02:15,https://github.com/decred/politeia/pull/131
+975,3,1,sndurkin,2017-11-09 15:14:49,https://github.com/decred/politeia/pull/130
+976,3,1,vctt94,2017-11-07 18:43:27,https://github.com/decred/politeia/pull/127
+977,3,1,rgeraldes,2017-11-07 16:35:16,https://github.com/decred/politeia/pull/126
+978,3,1,rgeraldes,2017-11-07 00:28:37,https://github.com/decred/politeia/pull/120
+979,3,1,rgeraldes,2017-11-06 22:48:48,https://github.com/decred/politeia/pull/119
+980,3,1,sndurkin,2017-11-05 18:23:43,https://github.com/decred/politeia/pull/117
+981,3,1,sndurkin,2017-11-05 05:09:15,https://github.com/decred/politeia/pull/116
+982,3,1,rgeraldes,2017-11-03 04:11:06,https://github.com/decred/politeia/pull/113
+983,3,1,rgeraldes,2017-11-02 22:21:41,https://github.com/decred/politeia/pull/112
+984,3,1,sndurkin,2017-11-02 15:18:13,https://github.com/decred/politeia/pull/108
+985,3,1,marcopeereboom,2017-10-31 16:03:09,https://github.com/decred/politeia/pull/106
+986,3,1,sndurkin,2017-10-30 14:09:51,https://github.com/decred/politeia/pull/105
+987,3,1,sndurkin,2017-10-30 02:59:34,https://github.com/decred/politeia/pull/104
+988,3,1,sndurkin,2017-10-28 14:34:15,https://github.com/decred/politeia/pull/103
+989,3,1,sndurkin,2017-10-26 14:23:10,https://github.com/decred/politeia/pull/98
+990,3,1,marcopeereboom,2017-10-25 16:26:33,https://github.com/decred/politeia/pull/94
+991,3,1,dajohi,2017-10-25 14:58:44,https://github.com/decred/politeia/pull/93
+992,3,1,marcopeereboom,2017-10-24 21:51:26,https://github.com/decred/politeia/pull/92
+993,3,1,sndurkin,2017-10-24 17:04:48,https://github.com/decred/politeia/pull/91
+994,3,1,sndurkin,2017-10-23 17:56:02,https://github.com/decred/politeia/pull/89
+995,3,1,sndurkin,2017-10-22 03:56:11,https://github.com/decred/politeia/pull/88
+996,3,1,sndurkin,2017-10-20 18:25:55,https://github.com/decred/politeia/pull/85
+997,3,1,sndurkin,2017-10-20 15:09:12,https://github.com/decred/politeia/pull/84
+998,3,1,marcopeereboom,2017-10-19 20:35:08,https://github.com/decred/politeia/pull/82
+999,3,1,marcopeereboom,2017-10-19 18:24:40,https://github.com/decred/politeia/pull/81
+1000,3,1,dajohi,2017-10-19 17:41:44,https://github.com/decred/politeia/pull/80
+1001,3,1,sndurkin,2017-10-19 14:58:06,https://github.com/decred/politeia/pull/77
+1002,3,1,marcopeereboom,2017-10-18 19:41:50,https://github.com/decred/politeia/pull/74
+1003,3,1,dajohi,2017-10-18 15:54:16,https://github.com/decred/politeia/pull/72
+1004,3,1,oktapodia,2017-10-18 14:23:50,https://github.com/decred/politeia/pull/71
+1005,3,1,go1dfish,2017-10-18 14:17:53,https://github.com/decred/politeia/pull/70
+1006,3,1,sndurkin,2017-10-18 13:58:47,https://github.com/decred/politeia/pull/69
+1007,3,1,marcopeereboom,2017-10-18 13:52:27,https://github.com/decred/politeia/pull/68
+1008,3,1,sndurkin,2017-10-18 13:26:23,https://github.com/decred/politeia/pull/67
+1009,3,1,sndurkin,2017-10-18 03:39:55,https://github.com/decred/politeia/pull/66
+1010,3,1,dajohi,2017-10-17 22:09:59,https://github.com/decred/politeia/pull/64
+1011,3,1,sndurkin,2017-10-17 16:35:29,https://github.com/decred/politeia/pull/62
+1012,3,1,dajohi,2017-10-17 16:26:29,https://github.com/decred/politeia/pull/61
+1013,3,1,sndurkin,2017-10-17 15:10:58,https://github.com/decred/politeia/pull/60
+1014,3,1,dajohi,2017-10-16 19:48:19,https://github.com/decred/politeia/pull/57
+1015,3,1,dajohi,2017-10-16 19:23:32,https://github.com/decred/politeia/pull/56
+1016,3,1,sndurkin,2017-10-16 13:23:56,https://github.com/decred/politeia/pull/54
+1017,3,1,marcopeereboom,2017-10-11 13:19:32,https://github.com/decred/politeia/pull/53
+1018,3,1,dajohi,2017-10-05 18:01:22,https://github.com/decred/politeia/pull/50
+1019,3,1,marcopeereboom,2017-10-05 13:07:59,https://github.com/decred/politeia/pull/49
+1020,3,1,sndurkin,2017-10-04 04:36:00,https://github.com/decred/politeia/pull/47
+1021,3,1,sndurkin,2017-10-01 03:00:23,https://github.com/decred/politeia/pull/45
+1022,3,1,sndurkin,2017-09-29 16:44:26,https://github.com/decred/politeia/pull/44
+1023,3,1,sndurkin,2017-09-28 02:51:21,https://github.com/decred/politeia/pull/38
+1024,3,1,dajohi,2017-09-27 20:01:51,https://github.com/decred/politeia/pull/37
+1025,3,1,sndurkin,2017-09-26 15:27:23,https://github.com/decred/politeia/pull/36
+1026,3,1,marcopeereboom,2017-09-21 15:50:58,https://github.com/decred/politeia/pull/35
+1027,3,1,sndurkin,2017-09-21 14:56:02,https://github.com/decred/politeia/pull/34
+1028,3,1,sndurkin,2017-09-21 02:36:22,https://github.com/decred/politeia/pull/33
+1029,3,1,marcopeereboom,2017-09-19 19:02:30,https://github.com/decred/politeia/pull/32
+1030,3,1,marcopeereboom,2017-09-18 15:55:28,https://github.com/decred/politeia/pull/25
+1031,3,1,sndurkin,2017-09-16 17:30:24,https://github.com/decred/politeia/pull/24
+1032,3,1,marcopeereboom,2017-09-15 16:03:06,https://github.com/decred/politeia/pull/23
+1033,3,1,sndurkin,2017-09-15 00:24:05,https://github.com/decred/politeia/pull/22
+1034,3,1,marcopeereboom,2017-09-14 19:27:51,https://github.com/decred/politeia/pull/21
+1035,3,1,marcopeereboom,2017-09-14 19:06:28,https://github.com/decred/politeia/pull/20
+1036,3,1,sndurkin,2017-09-14 15:23:31,https://github.com/decred/politeia/pull/19
+1037,3,1,marcopeereboom,2017-09-13 21:59:30,https://github.com/decred/politeia/pull/17
+1038,3,1,marcopeereboom,2017-09-13 21:10:32,https://github.com/decred/politeia/pull/16
+1039,3,1,marcopeereboom,2017-09-13 21:10:14,https://github.com/decred/politeia/pull/15
+1040,3,1,sndurkin,2017-09-13 02:19:56,https://github.com/decred/politeia/pull/12
+1041,3,1,marcopeereboom,2017-09-12 19:54:11,https://github.com/decred/politeia/pull/10
+1042,3,1,sndurkin,2017-09-12 13:14:18,https://github.com/decred/politeia/pull/9
+1043,3,1,marcopeereboom,2017-09-08 14:27:01,https://github.com/decred/politeia/pull/8
+1044,3,1,sndurkin,2017-09-07 14:27:33,https://github.com/decred/politeia/pull/7
+1045,3,1,marcopeereboom,2017-09-01 15:58:16,https://github.com/decred/politeia/pull/6
+1046,3,1,sndurkin,2017-08-29 13:27:46,https://github.com/decred/politeia/pull/4
+1047,3,1,marcopeereboom,2017-08-29 13:18:03,https://github.com/decred/politeia/pull/3
+1048,3,1,sndurkin,2017-08-25 04:32:04,https://github.com/decred/politeia/pull/1
+1054,2,1,dajohi,2019-03-25 18:24:46,https://github.com/decred/politeia/issues/751
+1058,2,1,lealife,2019-03-23 04:54:30,https://github.com/decred/politeia/issues/747
+1059,2,1,xaur,2019-03-22 16:12:00,https://github.com/decred/politeia/issues/746
+1066,2,1,dajohi,2019-03-21 13:26:48,https://github.com/decred/politeia/issues/739
+1067,2,1,dajohi,2019-03-20 18:07:49,https://github.com/decred/politeia/issues/738
+1068,2,1,dajohi,2019-03-20 17:56:04,https://github.com/decred/politeia/issues/737
+1069,2,1,xaur,2019-03-20 12:56:41,https://github.com/decred/politeia/issues/736
+1076,2,1,xaur,2019-03-16 14:45:38,https://github.com/decred/politeia/issues/729
+1082,2,1,lukebp,2019-03-11 18:09:21,https://github.com/decred/politeia/issues/723
+1085,2,1,xaur,2019-03-11 15:37:45,https://github.com/decred/politeia/issues/720
+1087,2,1,s-ben,2019-03-08 08:02:08,https://github.com/decred/politeia/issues/718
+1088,2,1,xaur,2019-03-05 22:12:13,https://github.com/decred/politeia/issues/717
+1089,2,1,lukebp,2019-03-05 17:01:52,https://github.com/decred/politeia/issues/716
+1092,2,1,davecgh,2019-03-04 10:22:18,https://github.com/decred/politeia/issues/713
+1093,2,1,lukebp,2019-03-02 20:54:59,https://github.com/decred/politeia/issues/712
+1099,2,1,lukebp,2019-02-26 16:22:40,https://github.com/decred/politeia/issues/706
+1101,2,1,lukebp,2019-02-25 16:34:37,https://github.com/decred/politeia/issues/704
+1107,2,1,marcopeereboom,2019-02-15 17:54:01,https://github.com/decred/politeia/issues/698
+1110,2,1,xaur,2019-02-14 07:43:08,https://github.com/decred/politeia/issues/695
+1113,2,1,lukebp,2019-02-13 14:18:17,https://github.com/decred/politeia/issues/692
+1114,2,1,s-ben,2019-02-12 20:02:35,https://github.com/decred/politeia/issues/691
+1120,2,1,camus-code,2019-02-05 21:34:22,https://github.com/decred/politeia/issues/685
+1127,2,1,linnutee,2019-01-25 17:24:59,https://github.com/decred/politeia/issues/678
+1129,2,1,thi4go,2019-01-24 22:20:02,https://github.com/decred/politeia/issues/676
+1132,2,1,jholdstock,2019-01-22 16:51:15,https://github.com/decred/politeia/issues/673
+1133,2,1,lukebp,2019-01-21 12:17:53,https://github.com/decred/politeia/issues/672
+1135,2,1,lukebp,2019-01-16 18:25:51,https://github.com/decred/politeia/issues/670
+1136,2,1,lukebp,2019-01-16 18:21:54,https://github.com/decred/politeia/issues/669
+1139,2,1,lemonkabir,2019-01-10 18:07:28,https://github.com/decred/politeia/issues/666
+1140,2,1,dajohi,2019-01-09 14:30:00,https://github.com/decred/politeia/issues/665
+1141,2,1,marcopeereboom,2019-01-08 17:00:34,https://github.com/decred/politeia/issues/664
+1143,2,1,lukebp,2019-01-07 20:09:58,https://github.com/decred/politeia/issues/662
+1144,2,1,naichadouban,2019-01-07 15:26:11,https://github.com/decred/politeia/issues/661
+1148,2,1,lemonkabir,2018-12-27 14:39:01,https://github.com/decred/politeia/issues/657
+1249,2,1,lukebp,2018-12-26 19:39:25,https://github.com/decred/politeia/issues/656
+1251,2,1,fernandoabolafio,2018-12-26 16:01:35,https://github.com/decred/politeia/issues/654
+1252,2,1,tpkeeper,2018-12-24 02:36:21,https://github.com/decred/politeia/issues/653
+1253,2,1,lemonkabir,2018-12-22 19:21:05,https://github.com/decred/politeia/issues/652
+1254,2,1,lemonkabir,2018-12-22 19:10:20,https://github.com/decred/politeia/issues/651
+1255,2,1,lemonkabir,2018-12-22 18:48:19,https://github.com/decred/politeia/issues/650
+1258,2,1,degeri,2018-12-19 17:04:41,https://github.com/decred/politeia/issues/647
+1263,2,1,lukebp,2018-12-13 23:42:33,https://github.com/decred/politeia/issues/642
+1275,2,1,lukebp,2018-12-03 13:07:21,https://github.com/decred/politeia/issues/630
+1276,2,1,degeri,2018-12-02 15:03:21,https://github.com/decred/politeia/issues/629
+1278,2,1,sndurkin,2018-11-30 14:10:12,https://github.com/decred/politeia/issues/627
+1283,2,1,lukebp,2018-11-29 14:10:23,https://github.com/decred/politeia/issues/622
+1284,2,1,lukebp,2018-11-29 13:56:40,https://github.com/decred/politeia/issues/621
+1286,2,1,Michae2xl,2018-11-26 18:46:11,https://github.com/decred/politeia/issues/619
+1287,2,1,matheusd,2018-11-26 18:16:07,https://github.com/decred/politeia/issues/618
+1291,2,1,lukebp,2018-11-22 16:18:54,https://github.com/decred/politeia/issues/614
+1293,2,1,brunobraga95,2018-11-20 16:17:10,https://github.com/decred/politeia/issues/612
+1294,2,1,oregonisaac,2018-11-20 03:31:58,https://github.com/decred/politeia/issues/611
+1297,2,1,degeri,2018-11-19 06:24:56,https://github.com/decred/politeia/issues/608
+1298,2,1,degeri,2018-11-19 04:52:18,https://github.com/decred/politeia/issues/607
+1300,2,1,dajohi,2018-11-16 15:30:00,https://github.com/decred/politeia/issues/605
+1302,2,1,lukebp,2018-11-15 15:17:35,https://github.com/decred/politeia/issues/603
+1304,2,1,lukebp,2018-11-14 14:33:59,https://github.com/decred/politeia/issues/601
+1308,2,1,tiagoalvesdulce,2018-11-13 17:45:55,https://github.com/decred/politeia/issues/597
+1309,2,1,fernandoabolafio,2018-11-13 17:38:57,https://github.com/decred/politeia/issues/596
+1312,2,1,xaur,2018-11-11 19:43:58,https://github.com/decred/politeia/issues/593
+1313,2,1,xaur,2018-11-11 19:36:22,https://github.com/decred/politeia/issues/592
+1314,2,1,xaur,2018-11-11 13:53:18,https://github.com/decred/politeia/issues/591
+1315,2,1,jzbz,2018-11-11 02:34:30,https://github.com/decred/politeia/issues/590
+1317,2,1,tiagoalvesdulce,2018-11-09 13:19:56,https://github.com/decred/politeia/issues/588
+1320,2,1,David00,2018-11-08 21:01:21,https://github.com/decred/politeia/issues/585
+1322,2,1,xaur,2018-11-07 19:47:23,https://github.com/decred/politeia/issues/583
+1323,2,1,fernandoabolafio,2018-11-07 19:10:16,https://github.com/decred/politeia/issues/582
+1325,2,1,lukebp,2018-11-05 12:48:10,https://github.com/decred/politeia/issues/580
+1327,2,1,sndurkin,2018-11-02 15:59:55,https://github.com/decred/politeia/issues/578
+1329,2,1,lukebp,2018-11-01 22:38:32,https://github.com/decred/politeia/issues/576
+1330,2,1,davecgh,2018-11-01 20:47:04,https://github.com/decred/politeia/issues/575
+1332,2,1,fernandoabolafio,2018-11-01 15:57:23,https://github.com/decred/politeia/issues/573
+1335,2,1,xaur,2018-10-31 17:58:17,https://github.com/decred/politeia/issues/570
+1336,2,1,xaur,2018-10-30 22:36:09,https://github.com/decred/politeia/issues/569
+1338,2,1,davecgh,2018-10-30 00:40:42,https://github.com/decred/politeia/issues/567
+1340,2,1,davecgh,2018-10-29 19:37:21,https://github.com/decred/politeia/issues/565
+1341,2,1,fernandoabolafio,2018-10-29 13:49:14,https://github.com/decred/politeia/issues/564
+1342,2,1,lukebp,2018-10-27 21:07:28,https://github.com/decred/politeia/issues/563
+1343,2,1,davecgh,2018-10-26 18:07:15,https://github.com/decred/politeia/issues/562
+1344,2,1,degeri,2018-10-26 14:54:17,https://github.com/decred/politeia/issues/561
+1345,2,1,xaur,2018-10-26 10:13:48,https://github.com/decred/politeia/issues/560
+1347,2,1,xaur,2018-10-25 19:08:11,https://github.com/decred/politeia/issues/558
+1349,2,1,dajohi,2018-10-23 19:00:13,https://github.com/decred/politeia/issues/556
+1350,2,1,fernandoabolafio,2018-10-23 14:15:17,https://github.com/decred/politeia/issues/555
+1351,2,1,xaur,2018-10-23 11:21:38,https://github.com/decred/politeia/issues/554
+1358,2,1,marcopeereboom,2018-10-18 19:19:12,https://github.com/decred/politeia/issues/547
+1359,2,1,marcopeereboom,2018-10-18 18:55:01,https://github.com/decred/politeia/issues/546
+1360,2,1,marcopeereboom,2018-10-18 18:40:06,https://github.com/decred/politeia/issues/545
+1361,2,1,marcopeereboom,2018-10-18 18:30:12,https://github.com/decred/politeia/issues/544
+1362,2,1,marcopeereboom,2018-10-18 17:58:27,https://github.com/decred/politeia/issues/543
+1366,2,1,marcopeereboom,2018-10-17 19:29:36,https://github.com/decred/politeia/issues/539
+1367,2,1,marcopeereboom,2018-10-17 17:22:47,https://github.com/decred/politeia/issues/538
+1368,2,1,marcopeereboom,2018-10-17 17:17:44,https://github.com/decred/politeia/issues/537
+1370,2,1,marcopeereboom,2018-10-17 16:32:08,https://github.com/decred/politeia/issues/535
+1371,2,1,RichardRed0x,2018-10-17 14:21:59,https://github.com/decred/politeia/issues/534
+1377,2,1,sndurkin,2018-10-16 15:02:43,https://github.com/decred/politeia/issues/528
+1378,2,1,marcopeereboom,2018-10-16 13:34:00,https://github.com/decred/politeia/issues/527
+1380,2,1,lukebp,2018-10-16 01:26:15,https://github.com/decred/politeia/issues/525
+1381,2,1,marcopeereboom,2018-10-15 21:23:07,https://github.com/decred/politeia/issues/524
+1383,2,1,lukebp,2018-10-15 20:10:03,https://github.com/decred/politeia/issues/522
+1391,2,1,tiagoalvesdulce,2018-10-10 20:55:01,https://github.com/decred/politeia/issues/514
+1392,2,1,matheusd,2018-10-10 11:10:59,https://github.com/decred/politeia/issues/513
+1394,2,1,fernandoabolafio,2018-10-08 14:14:28,https://github.com/decred/politeia/issues/511
+1396,2,1,fernandoabolafio,2018-10-05 21:35:25,https://github.com/decred/politeia/issues/509
+1397,2,1,lukebp,2018-10-05 21:15:41,https://github.com/decred/politeia/issues/508
+1398,2,1,marcopeereboom,2018-10-05 21:05:43,https://github.com/decred/politeia/issues/507
+1400,2,1,lukebp,2018-10-04 20:47:06,https://github.com/decred/politeia/issues/505
+1404,2,1,dajohi,2018-10-04 16:06:29,https://github.com/decred/politeia/issues/501
+1405,2,1,marcopeereboom,2018-10-03 22:20:19,https://github.com/decred/politeia/issues/500
+1406,2,1,degeri,2018-10-03 17:47:22,https://github.com/decred/politeia/issues/499
+1407,2,1,fernandoabolafio,2018-10-03 14:45:13,https://github.com/decred/politeia/issues/498
+1415,2,1,marcopeereboom,2018-09-27 13:09:06,https://github.com/decred/politeia/issues/490
+1419,2,1,marcopeereboom,2018-09-26 19:11:03,https://github.com/decred/politeia/issues/486
+1424,2,1,camus-code,2018-09-24 17:59:13,https://github.com/decred/politeia/issues/481
+1426,2,1,marcopeereboom,2018-09-24 14:31:57,https://github.com/decred/politeia/issues/479
+1427,2,1,degeri,2018-09-21 19:41:01,https://github.com/decred/politeia/issues/478
+1431,2,1,lukebp,2018-09-20 13:21:40,https://github.com/decred/politeia/issues/474
+1442,2,1,lukebp,2018-09-11 11:22:46,https://github.com/decred/politeia/issues/463
+1443,2,1,tiagoalvesdulce,2018-09-10 18:28:59,https://github.com/decred/politeia/issues/462
+1444,2,1,fernandoabolafio,2018-09-10 18:00:26,https://github.com/decred/politeia/issues/461
+1446,2,1,tiagoalvesdulce,2018-09-07 19:37:47,https://github.com/decred/politeia/issues/459
+1449,2,1,marcopeereboom,2018-09-06 19:33:09,https://github.com/decred/politeia/issues/456
+1451,2,1,lukebp,2018-09-06 13:22:48,https://github.com/decred/politeia/issues/454
+1452,2,1,lukebp,2018-09-06 00:08:29,https://github.com/decred/politeia/issues/453
+1455,2,1,marcopeereboom,2018-09-05 16:26:54,https://github.com/decred/politeia/issues/450
+1456,2,1,marcopeereboom,2018-09-05 16:14:49,https://github.com/decred/politeia/issues/449
+1457,2,1,marcopeereboom,2018-09-05 16:09:21,https://github.com/decred/politeia/issues/448
+1458,2,1,marcopeereboom,2018-09-05 14:42:12,https://github.com/decred/politeia/issues/447
+1459,2,1,marcopeereboom,2018-09-05 14:28:35,https://github.com/decred/politeia/issues/446
+1460,2,1,marcopeereboom,2018-09-05 14:26:12,https://github.com/decred/politeia/issues/445
+1461,2,1,marcopeereboom,2018-09-05 13:55:17,https://github.com/decred/politeia/issues/444
+1464,2,1,RichardRed0x,2018-09-04 23:21:00,https://github.com/decred/politeia/issues/441
+1478,2,1,marcopeereboom,2018-08-28 22:06:29,https://github.com/decred/politeia/issues/427
+1479,2,1,marcopeereboom,2018-08-28 22:00:31,https://github.com/decred/politeia/issues/426
+1484,2,1,lukebp,2018-08-10 21:09:02,https://github.com/decred/politeia/issues/421
+1489,2,1,fernandoabolafio,2018-08-06 20:48:51,https://github.com/decred/politeia/issues/416
+1491,2,1,degeri,2018-08-04 14:07:00,https://github.com/decred/politeia/issues/414
+1498,2,1,sndurkin,2018-07-27 19:20:50,https://github.com/decred/politeia/issues/407
+1500,2,1,lukebp,2018-07-25 17:36:20,https://github.com/decred/politeia/issues/405
+1502,2,1,sndurkin,2018-07-24 13:58:13,https://github.com/decred/politeia/issues/403
+1503,2,1,hsanjuan,2018-07-23 22:54:39,https://github.com/decred/politeia/issues/402
+1506,2,1,lukebp,2018-07-21 19:08:15,https://github.com/decred/politeia/issues/399
+1508,2,1,lukebp,2018-07-21 17:37:08,https://github.com/decred/politeia/issues/397
+1509,2,1,fernandoabolafio,2018-07-21 13:59:55,https://github.com/decred/politeia/issues/396
+1517,2,1,rrecuero,2018-07-15 20:49:57,https://github.com/decred/politeia/issues/388
+1521,2,1,sndurkin,2018-07-12 16:45:43,https://github.com/decred/politeia/issues/384
+1522,2,1,sndurkin,2018-07-12 16:33:07,https://github.com/decred/politeia/issues/383
+1524,2,1,marcopeereboom,2018-07-12 10:55:52,https://github.com/decred/politeia/issues/381
+1525,2,1,sndurkin,2018-07-12 04:07:39,https://github.com/decred/politeia/issues/380
+1526,2,1,dajohi,2018-07-11 20:25:19,https://github.com/decred/politeia/issues/379
+1528,2,1,dajohi,2018-07-11 19:01:09,https://github.com/decred/politeia/issues/377
+1529,2,1,fernandoabolafio,2018-07-09 11:44:41,https://github.com/decred/politeia/issues/376
+1533,2,1,fernandoabolafio,2018-07-05 20:09:49,https://github.com/decred/politeia/issues/372
+1536,2,1,tiagoalvesdulce,2018-07-03 16:55:56,https://github.com/decred/politeia/issues/369
+1537,2,1,sndurkin,2018-07-03 16:01:52,https://github.com/decred/politeia/issues/368
+1539,2,1,marcopeereboom,2018-07-03 12:11:05,https://github.com/decred/politeia/issues/366
+1541,2,1,marcopeereboom,2018-07-03 10:44:01,https://github.com/decred/politeia/issues/364
+1543,2,1,fernandoabolafio,2018-07-02 16:28:22,https://github.com/decred/politeia/issues/362
+1547,2,1,marcopeereboom,2018-06-28 12:11:02,https://github.com/decred/politeia/issues/358
+1548,2,1,RichardRed0x,2018-06-28 12:10:10,https://github.com/decred/politeia/issues/357
+1549,2,1,RichardRed0x,2018-06-28 09:41:58,https://github.com/decred/politeia/issues/356
+1550,2,1,tiagoalvesdulce,2018-06-26 19:01:37,https://github.com/decred/politeia/issues/355
+1551,2,1,fernandoabolafio,2018-06-26 15:30:16,https://github.com/decred/politeia/issues/354
+1552,2,1,tiagoalvesdulce,2018-06-26 01:40:08,https://github.com/decred/politeia/issues/353
+1555,2,1,fernandoabolafio,2018-06-22 17:52:29,https://github.com/decred/politeia/issues/350
+1556,2,1,sndurkin,2018-06-22 16:55:03,https://github.com/decred/politeia/issues/349
+1558,2,1,marcopeereboom,2018-06-22 10:42:40,https://github.com/decred/politeia/issues/347
+1559,2,1,marcopeereboom,2018-06-22 10:39:43,https://github.com/decred/politeia/issues/346
+1562,2,1,fernandoabolafio,2018-06-21 17:16:41,https://github.com/decred/politeia/issues/343
+1565,2,1,fernandoabolafio,2018-06-21 13:08:15,https://github.com/decred/politeia/issues/340
+1566,2,1,RichardRed0x,2018-06-21 05:10:44,https://github.com/decred/politeia/issues/339
+1570,2,1,fernandoabolafio,2018-06-20 19:39:47,https://github.com/decred/politeia/issues/335
+1573,2,1,fernandoabolafio,2018-06-19 20:31:10,https://github.com/decred/politeia/issues/332
+1575,2,1,tiagoalvesdulce,2018-06-18 14:45:35,https://github.com/decred/politeia/issues/330
+1580,2,1,tiagoalvesdulce,2018-06-13 20:21:44,https://github.com/decred/politeia/issues/325
+1581,2,1,dajohi,2018-06-13 18:36:50,https://github.com/decred/politeia/issues/324
+1586,2,1,sndurkin,2018-06-12 17:40:16,https://github.com/decred/politeia/issues/319
+1588,2,1,marcopeereboom,2018-06-11 12:47:58,https://github.com/decred/politeia/issues/317
+1590,2,1,marcopeereboom,2018-06-11 09:56:52,https://github.com/decred/politeia/issues/315
+1591,2,1,marcopeereboom,2018-06-11 09:24:32,https://github.com/decred/politeia/issues/314
+1592,2,1,marcopeereboom,2018-06-11 08:54:34,https://github.com/decred/politeia/issues/313
+1593,2,1,fernandoabolafio,2018-06-09 17:29:44,https://github.com/decred/politeia/issues/312
+1595,2,1,lukebp,2018-06-06 16:14:02,https://github.com/decred/politeia/issues/310
+1597,2,1,lukebp,2018-06-04 19:29:53,https://github.com/decred/politeia/issues/308
+1599,2,1,sndurkin,2018-06-01 17:42:26,https://github.com/decred/politeia/issues/306
+1606,2,1,marcopeereboom,2018-05-25 19:09:18,https://github.com/decred/politeia/issues/299
+1607,2,1,fernandoabolafio,2018-05-24 22:52:06,https://github.com/decred/politeia/issues/298
+1609,2,1,marcopeereboom,2018-05-24 13:43:07,https://github.com/decred/politeia/issues/296
+1610,2,1,marcopeereboom,2018-05-24 13:41:23,https://github.com/decred/politeia/issues/295
+1612,2,1,lukebp,2018-05-24 05:08:09,https://github.com/decred/politeia/issues/293
+1614,2,1,lukebp,2018-05-24 05:00:07,https://github.com/decred/politeia/issues/291
+1617,2,1,sndurkin,2018-05-17 03:00:52,https://github.com/decred/politeia/issues/288
+1618,2,1,fernandoabolafio,2018-05-16 14:28:12,https://github.com/decred/politeia/issues/287
+1620,2,1,fernandoabolafio,2018-05-15 19:15:40,https://github.com/decred/politeia/issues/285
+1625,2,1,lukebp,2018-05-11 18:06:58,https://github.com/decred/politeia/issues/280
+1627,2,1,sndurkin,2018-05-10 18:06:41,https://github.com/decred/politeia/issues/278
+1629,2,1,fernandoabolafio,2018-05-10 14:04:17,https://github.com/decred/politeia/issues/276
+1635,2,1,fernandoabolafio,2018-05-07 16:20:54,https://github.com/decred/politeia/issues/270
+1637,2,1,fernandoabolafio,2018-05-07 13:58:00,https://github.com/decred/politeia/issues/268
+1639,2,1,RichardRed0x,2018-05-01 14:43:24,https://github.com/decred/politeia/issues/266
+1640,2,1,marcopeereboom,2018-04-30 13:53:45,https://github.com/decred/politeia/issues/265
+1641,2,1,marcopeereboom,2018-04-30 13:49:42,https://github.com/decred/politeia/issues/264
+1642,2,1,marcopeereboom,2018-04-30 13:47:30,https://github.com/decred/politeia/issues/263
+1643,2,1,marcopeereboom,2018-04-30 13:45:49,https://github.com/decred/politeia/issues/262
+1644,2,1,lukebp,2018-04-30 03:08:19,https://github.com/decred/politeia/issues/261
+1646,2,1,marcopeereboom,2018-04-19 22:01:11,https://github.com/decred/politeia/issues/259
+1653,2,1,marcopeereboom,2018-04-17 15:03:32,https://github.com/decred/politeia/issues/252
+1668,2,1,vctt94,2018-03-22 15:40:54,https://github.com/decred/politeia/issues/237
+1672,2,1,sndurkin,2018-02-22 15:45:52,https://github.com/decred/politeia/issues/233
+1680,2,1,AlanL1,2018-02-12 08:49:53,https://github.com/decred/politeia/issues/225
+1682,2,1,fernandoabolafio,2018-02-05 01:30:16,https://github.com/decred/politeia/issues/223
+1685,2,1,tiagoalvesdulce,2018-01-30 13:40:53,https://github.com/decred/politeia/issues/220
+1687,2,1,jolan,2018-01-22 15:00:18,https://github.com/decred/politeia/issues/218
+1688,2,1,sndurkin,2018-01-21 06:26:34,https://github.com/decred/politeia/issues/217
+1692,2,1,sndurkin,2018-01-16 17:10:42,https://github.com/decred/politeia/issues/213
+1694,2,1,sndurkin,2018-01-16 03:05:01,https://github.com/decred/politeia/issues/211
+1695,2,1,brunobraga95,2018-01-16 02:28:05,https://github.com/decred/politeia/issues/210
+1696,2,1,vctt94,2018-01-15 18:10:19,https://github.com/decred/politeia/issues/209
+1697,2,1,sndurkin,2018-01-15 17:41:02,https://github.com/decred/politeia/issues/208
+1698,2,1,sndurkin,2018-01-15 15:49:53,https://github.com/decred/politeia/issues/207
+1704,2,1,sndurkin,2018-01-11 15:12:49,https://github.com/decred/politeia/issues/201
+1706,2,1,sndurkin,2018-01-08 19:44:15,https://github.com/decred/politeia/issues/199
+1708,2,1,sndurkin,2018-01-08 16:31:54,https://github.com/decred/politeia/issues/197
+1711,2,1,fernandoabolafio,2017-12-26 16:23:24,https://github.com/decred/politeia/issues/194
+1712,2,1,dajohi,2017-12-15 20:43:07,https://github.com/decred/politeia/issues/193
+1717,2,1,sndurkin,2017-12-12 21:50:27,https://github.com/decred/politeia/issues/188
+1719,2,1,sndurkin,2017-12-07 15:08:31,https://github.com/decred/politeia/issues/186
+1720,2,1,marcopeereboom,2017-12-04 19:55:33,https://github.com/decred/politeia/issues/185
+1721,2,1,marcopeereboom,2017-12-04 19:45:07,https://github.com/decred/politeia/issues/184
+1725,2,1,rgeraldes,2017-12-03 20:46:17,https://github.com/decred/politeia/issues/180
+1726,2,1,rgeraldes,2017-12-03 00:23:08,https://github.com/decred/politeia/issues/179
+1728,2,1,rgeraldes,2017-12-01 19:02:38,https://github.com/decred/politeia/issues/177
+1736,2,1,sndurkin,2017-12-01 02:09:13,https://github.com/decred/politeia/issues/169
+1737,2,1,sndurkin,2017-12-01 00:09:58,https://github.com/decred/politeia/issues/168
+1738,2,1,marcopeereboom,2017-11-30 15:22:57,https://github.com/decred/politeia/issues/167
+1739,2,1,marcopeereboom,2017-11-30 15:12:27,https://github.com/decred/politeia/issues/166
+1743,2,1,oktapodia,2017-11-29 16:11:52,https://github.com/decred/politeia/issues/162
+1744,2,1,oktapodia,2017-11-29 16:10:25,https://github.com/decred/politeia/issues/161
+1750,2,1,rgeraldes,2017-11-20 15:14:10,https://github.com/decred/politeia/issues/155
+1752,2,1,JFixby,2017-11-20 14:30:16,https://github.com/decred/politeia/issues/153
+1755,2,1,vctt94,2017-11-16 19:05:58,https://github.com/decred/politeia/issues/150
+1757,2,1,marcopeereboom,2017-11-16 17:03:07,https://github.com/decred/politeia/issues/148
+1758,2,1,sndurkin,2017-11-16 16:59:26,https://github.com/decred/politeia/issues/147
+1759,2,1,go1dfish,2017-11-16 15:58:26,https://github.com/decred/politeia/issues/146
+1760,2,1,rgeraldes,2017-11-16 02:48:10,https://github.com/decred/politeia/issues/145
+1770,2,1,sndurkin,2017-11-10 23:07:22,https://github.com/decred/politeia/issues/135
+1773,2,1,marcopeereboom,2017-11-09 18:37:45,https://github.com/decred/politeia/issues/132
+1776,2,1,sndurkin,2017-11-08 21:29:10,https://github.com/decred/politeia/issues/129
+1777,2,1,sndurkin,2017-11-08 20:19:40,https://github.com/decred/politeia/issues/128
+1780,2,1,jolan,2017-11-07 16:21:51,https://github.com/decred/politeia/issues/125
+1781,2,1,jolan,2017-11-07 16:20:27,https://github.com/decred/politeia/issues/124
+1782,2,1,jolan,2017-11-07 16:15:05,https://github.com/decred/politeia/issues/123
+1783,2,1,sndurkin,2017-11-07 05:04:09,https://github.com/decred/politeia/issues/122
+1784,2,1,sndurkin,2017-11-07 04:06:49,https://github.com/decred/politeia/issues/121
+1787,2,1,sndurkin,2017-11-06 18:25:43,https://github.com/decred/politeia/issues/118
+1790,2,1,sndurkin,2017-11-03 19:06:29,https://github.com/decred/politeia/issues/115
+1791,2,1,sndurkin,2017-11-03 14:37:24,https://github.com/decred/politeia/issues/114
+1794,2,1,sndurkin,2017-11-02 17:16:13,https://github.com/decred/politeia/issues/111
+1795,2,1,sndurkin,2017-11-02 16:07:58,https://github.com/decred/politeia/issues/110
+1796,2,1,sndurkin,2017-11-02 16:07:03,https://github.com/decred/politeia/issues/109
+1798,2,1,marcopeereboom,2017-11-02 12:39:24,https://github.com/decred/politeia/issues/107
+1803,2,1,sndurkin,2017-10-27 22:15:55,https://github.com/decred/politeia/issues/102
+1804,2,1,sndurkin,2017-10-27 17:18:15,https://github.com/decred/politeia/issues/101
+1805,2,1,sndurkin,2017-10-27 14:05:26,https://github.com/decred/politeia/issues/100
+1806,2,1,sndurkin,2017-10-27 13:33:12,https://github.com/decred/politeia/issues/99
+1808,2,1,sndurkin,2017-10-25 21:09:24,https://github.com/decred/politeia/issues/97
+1809,2,1,sndurkin,2017-10-25 19:12:02,https://github.com/decred/politeia/issues/96
+1810,2,1,sndurkin,2017-10-25 19:09:17,https://github.com/decred/politeia/issues/95
+1815,2,1,dajohi,2017-10-24 14:34:21,https://github.com/decred/politeia/issues/90
+1818,2,1,sndurkin,2017-10-20 21:03:01,https://github.com/decred/politeia/issues/87
+1819,2,1,dajohi,2017-10-20 18:49:44,https://github.com/decred/politeia/issues/86
+1822,2,1,sndurkin,2017-10-20 13:46:37,https://github.com/decred/politeia/issues/83
+1826,2,1,sndurkin,2017-10-19 16:49:47,https://github.com/decred/politeia/issues/79
+1827,2,1,dajohi,2017-10-19 15:10:48,https://github.com/decred/politeia/issues/78
+1829,2,1,sndurkin,2017-10-18 22:10:06,https://github.com/decred/politeia/issues/76
+1830,2,1,sndurkin,2017-10-18 20:57:05,https://github.com/decred/politeia/issues/75
+1832,2,1,marcopeereboom,2017-10-18 16:50:41,https://github.com/decred/politeia/issues/73
+1840,2,1,sndurkin,2017-10-18 03:11:35,https://github.com/decred/politeia/issues/65
+1842,2,1,sndurkin,2017-10-17 22:01:09,https://github.com/decred/politeia/issues/63
+1846,2,1,sndurkin,2017-10-16 21:20:27,https://github.com/decred/politeia/issues/59
+1847,2,1,sndurkin,2017-10-16 20:39:24,https://github.com/decred/politeia/issues/58
+1850,2,1,dajohi,2017-10-16 19:01:51,https://github.com/decred/politeia/issues/55
+1853,2,1,sndurkin,2017-10-05 18:38:14,https://github.com/decred/politeia/issues/52
+1854,2,1,sndurkin,2017-10-05 18:34:32,https://github.com/decred/politeia/issues/51
+1857,2,1,go1dfish,2017-10-04 16:38:38,https://github.com/decred/politeia/issues/48
+1859,2,1,marcopeereboom,2017-10-03 18:57:07,https://github.com/decred/politeia/issues/46
+1862,2,1,sndurkin,2017-09-29 16:40:46,https://github.com/decred/politeia/issues/43
+1863,2,1,sndurkin,2017-09-29 16:38:36,https://github.com/decred/politeia/issues/42
+1864,2,1,sndurkin,2017-09-29 16:23:08,https://github.com/decred/politeia/issues/41
+1865,2,1,marcopeereboom,2017-09-29 16:19:54,https://github.com/decred/politeia/issues/40
+1866,2,1,go1dfish,2017-09-29 15:12:12,https://github.com/decred/politeia/issues/39
+1874,2,1,marcopeereboom,2017-09-19 13:59:35,https://github.com/decred/politeia/issues/31
+1875,2,1,marcopeereboom,2017-09-19 13:57:25,https://github.com/decred/politeia/issues/30
+1876,2,1,marcopeereboom,2017-09-19 13:55:30,https://github.com/decred/politeia/issues/29
+1877,2,1,marcopeereboom,2017-09-19 13:53:14,https://github.com/decred/politeia/issues/28
+1878,2,1,marcopeereboom,2017-09-19 13:51:01,https://github.com/decred/politeia/issues/27
+1879,2,1,marcopeereboom,2017-09-19 13:46:56,https://github.com/decred/politeia/issues/26
+1887,2,1,marcopeereboom,2017-09-14 01:43:48,https://github.com/decred/politeia/issues/18
+1891,2,1,marcopeereboom,2017-09-13 15:32:08,https://github.com/decred/politeia/issues/14
+1892,2,1,marcopeereboom,2017-09-13 15:23:52,https://github.com/decred/politeia/issues/13
+1894,2,1,marcopeereboom,2017-09-12 22:07:48,https://github.com/decred/politeia/issues/11
+1900,2,1,dajohi,2017-08-29 18:04:31,https://github.com/decred/politeia/issues/5
+1903,2,1,sndurkin,2017-08-25 04:49:45,https://github.com/decred/politeia/issues/2
+1905,4,1,marcopeereboom,2017-09-12 22:00:50,https://github.com/decred/politeia/pull/8#issuecomment-328996941
+1906,4,1,marcopeereboom,2017-09-12 22:20:01,https://github.com/decred/politeia/pull/9#issuecomment-329000710
+1907,4,1,marcopeereboom,2017-09-13 15:33:46,https://github.com/decred/politeia/issues/5#issuecomment-329206564
+1908,4,1,go1dfish,2017-09-19 14:34:56,https://github.com/decred/politeia/issues/29#issuecomment-330559725
+1909,4,1,marcopeereboom,2017-09-27 14:24:15,https://github.com/decred/politeia/issues/18#issuecomment-332538221
+1910,4,1,sndurkin,2017-09-29 15:15:06,https://github.com/decred/politeia/issues/39#issuecomment-333154641
+1911,4,1,go1dfish,2017-10-04 16:40:51,https://github.com/decred/politeia/issues/43#issuecomment-334216361
+1912,4,1,sndurkin,2017-10-05 15:11:38,https://github.com/decred/politeia/pull/49#issuecomment-334495926
+1913,4,1,marcopeereboom,2017-10-05 18:43:20,https://github.com/decred/politeia/issues/51#issuecomment-334555909
+1914,4,1,dajohi,2017-10-06 19:56:06,https://github.com/decred/politeia/issues/52#issuecomment-334854658
+1915,4,1,dajohi,2017-10-06 20:58:48,https://github.com/decred/politeia/issues/46#issuecomment-334868517
+1916,4,1,jrick,2017-10-07 00:30:59,https://github.com/decred/politeia/issues/46#issuecomment-334898008
+1917,4,1,dajohi,2017-10-16 19:23:44,https://github.com/decred/politeia/pull/56#issuecomment-337005879
+1918,4,1,dajohi,2017-10-18 22:16:30,https://github.com/decred/politeia/issues/52#issuecomment-337743988
+1919,4,1,dajohi,2017-10-18 22:17:01,https://github.com/decred/politeia/issues/55#issuecomment-337744093
+1920,4,1,sndurkin,2017-10-19 00:32:46,https://github.com/decred/politeia/issues/75#issuecomment-337765771
+1921,4,1,sndurkin,2017-10-19 18:02:18,https://github.com/decred/politeia/issues/75#issuecomment-337988924
+1922,4,1,sndurkin,2017-10-19 19:00:34,https://github.com/decred/politeia/issues/78#issuecomment-338005082
+1923,4,1,go1dfish,2017-10-19 19:37:22,https://github.com/decred/politeia/pull/80#issuecomment-338014250
+1924,4,1,go1dfish,2017-10-20 21:05:48,https://github.com/decred/politeia/issues/87#issuecomment-338322189
+1925,4,1,marcopeereboom,2017-10-20 21:12:46,https://github.com/decred/politeia/issues/87#issuecomment-338323485
+1926,4,1,marcopeereboom,2017-10-23 16:26:25,https://github.com/decred/politeia/issues/78#issuecomment-338716162
+1927,4,1,marcopeereboom,2017-10-23 16:26:45,https://github.com/decred/politeia/issues/30#issuecomment-338716255
+1928,4,1,marcopeereboom,2017-10-23 16:27:00,https://github.com/decred/politeia/issues/31#issuecomment-338716328
+1929,4,1,dajohi,2017-10-24 14:33:38,https://github.com/decred/politeia/pull/70#issuecomment-339011146
+1930,4,1,marcopeereboom,2017-10-26 15:48:01,https://github.com/decred/politeia/issues/78#issuecomment-339710561
+1931,4,1,marcopeereboom,2017-10-31 14:56:34,https://github.com/decred/politeia/issues/83#issuecomment-340788672
+1932,4,1,sndurkin,2017-10-31 15:07:00,https://github.com/decred/politeia/issues/83#issuecomment-340792168
+1933,4,1,marcopeereboom,2017-11-02 12:34:45,https://github.com/decred/politeia/issues/97#issuecomment-341407414
+1934,4,1,rgeraldes,2017-11-02 22:29:15,https://github.com/decred/politeia/issues/65#issuecomment-341577120
+1935,4,1,sndurkin,2017-11-02 22:52:29,https://github.com/decred/politeia/issues/65#issuecomment-341581438
+1936,4,1,rgeraldes,2017-11-05 00:49:34,https://github.com/decred/politeia/issues/76#issuecomment-341940939
+1937,4,1,sndurkin,2017-11-05 15:40:04,https://github.com/decred/politeia/issues/76#issuecomment-341982194
+1938,4,1,marcopeereboom,2017-11-07 02:36:03,https://github.com/decred/politeia/pull/116#issuecomment-342356999
+1939,4,1,marcopeereboom,2017-11-07 02:38:16,https://github.com/decred/politeia/pull/120#issuecomment-342357326
+1940,4,1,sndurkin,2017-11-07 05:07:09,https://github.com/decred/politeia/pull/116#issuecomment-342377022
+1941,4,1,marcopeereboom,2017-11-07 11:30:37,https://github.com/decred/politeia/issues/121#issuecomment-342455130
+1942,4,1,marcopeereboom,2017-11-07 11:31:20,https://github.com/decred/politeia/issues/122#issuecomment-342455287
+1943,4,1,sndurkin,2017-11-08 02:31:38,https://github.com/decred/politeia/pull/116#issuecomment-342690701
+1944,4,1,marcopeereboom,2017-11-08 14:49:01,https://github.com/decred/politeia/pull/113#issuecomment-342839802
+1945,4,1,marcopeereboom,2017-11-08 14:53:46,https://github.com/decred/politeia/pull/127#issuecomment-342841318
+1946,4,1,sndurkin,2017-11-08 15:27:19,https://github.com/decred/politeia/pull/126#issuecomment-342852132
+1947,4,1,sndurkin,2017-11-08 16:07:50,https://github.com/decred/politeia/issues/76#issuecomment-342865513
+1948,4,1,marcopeereboom,2017-11-08 19:39:43,https://github.com/decred/politeia/pull/126#issuecomment-342935153
+1949,4,1,marcopeereboom,2017-11-09 22:42:38,https://github.com/decred/politeia/pull/133#issuecomment-343316180
+1950,4,1,rgeraldes,2017-11-10 03:45:00,https://github.com/decred/politeia/pull/112#issuecomment-343366858
+1951,4,1,marcopeereboom,2017-11-10 19:15:47,https://github.com/decred/politeia/pull/127#issuecomment-343561170
+1952,4,1,rgeraldes,2017-11-12 21:51:31,https://github.com/decred/politeia/issues/109#issuecomment-343770970
+1953,4,1,sudoscript,2017-11-13 04:08:53,https://github.com/decred/politeia/issues/132#issuecomment-343805654
+1954,4,1,sudoscript,2017-11-13 04:29:17,https://github.com/decred/politeia/issues/132#issuecomment-343809058
+1955,4,1,marcopeereboom,2017-11-13 19:16:33,https://github.com/decred/politeia/pull/127#issuecomment-344026593
+1956,4,1,sndurkin,2017-11-14 22:51:05,https://github.com/decred/politeia/issues/111#issuecomment-344426719
+1957,4,1,vctt94,2017-11-15 00:04:18,https://github.com/decred/politeia/issues/83#issuecomment-344441901
+1958,4,1,sndurkin,2017-11-15 14:00:14,https://github.com/decred/politeia/issues/109#issuecomment-344600390
+1959,4,1,sndurkin,2017-11-15 18:27:14,https://github.com/decred/politeia/pull/136#issuecomment-344683907
+1960,4,1,rgeraldes,2017-11-16 16:44:44,https://github.com/decred/politeia/issues/146#issuecomment-344983494
+1961,4,1,rgeraldes,2017-11-16 21:48:22,https://github.com/decred/politeia/issues/118#issuecomment-345073438
+1962,4,1,jolan,2017-11-16 22:28:55,https://github.com/decred/politeia/issues/124#issuecomment-345083581
+1963,4,1,rgeraldes,2017-11-20 14:20:18,https://github.com/decred/politeia/pull/149#issuecomment-345708906
+1964,4,1,JFixby,2017-11-20 14:52:13,https://github.com/decred/politeia/issues/153#issuecomment-345718450
+1965,4,1,rgeraldes,2017-11-21 06:14:43,https://github.com/decred/politeia/pull/154#issuecomment-345927783
+1966,4,1,sudoscript,2017-11-21 06:47:14,https://github.com/decred/politeia/pull/141#issuecomment-345932796
+1967,4,1,jolan,2017-11-22 22:52:33,https://github.com/decred/politeia/pull/158#issuecomment-346494368
+1968,4,1,sndurkin,2017-11-28 03:58:54,https://github.com/decred/politeia/pull/158#issuecomment-347406767
+1969,4,1,jolan,2017-11-28 19:51:13,https://github.com/decred/politeia/pull/158#issuecomment-347643199
+1970,4,1,marcopeereboom,2017-11-29 18:05:49,https://github.com/decred/politeia/pull/131#issuecomment-347945542
+1971,4,1,rgeraldes,2017-11-30 12:21:08,https://github.com/decred/politeia/issues/162#issuecomment-348173036
+1972,4,1,marcopeereboom,2017-11-30 13:25:36,https://github.com/decred/politeia/pull/159#issuecomment-348187022
+1973,4,1,marcopeereboom,2017-11-30 13:30:30,https://github.com/decred/politeia/pull/160#issuecomment-348188240
+1974,4,1,vctt94,2017-11-30 15:28:29,https://github.com/decred/politeia/issues/166#issuecomment-348222126
+1975,4,1,sndurkin,2017-11-30 15:54:33,https://github.com/decred/politeia/issues/162#issuecomment-348230734
+1976,4,1,go1dfish,2017-11-30 16:23:06,https://github.com/decred/politeia/pull/152#issuecomment-348240183
+1977,4,1,marcopeereboom,2017-12-01 18:14:45,https://github.com/decred/politeia/pull/141#issuecomment-348567895
+1978,4,1,marcopeereboom,2017-12-01 18:15:18,https://github.com/decred/politeia/pull/144#issuecomment-348568030
+1979,4,1,marcopeereboom,2017-12-01 18:15:45,https://github.com/decred/politeia/pull/151#issuecomment-348568104
+1980,4,1,marcopeereboom,2017-12-01 18:16:20,https://github.com/decred/politeia/pull/152#issuecomment-348568218
+1981,4,1,marcopeereboom,2017-12-01 18:17:29,https://github.com/decred/politeia/pull/160#issuecomment-348568497
+1982,4,1,marcopeereboom,2017-12-01 18:22:03,https://github.com/decred/politeia/issues/13#issuecomment-348569668
+1983,4,1,marcopeereboom,2017-12-01 18:22:55,https://github.com/decred/politeia/issues/28#issuecomment-348569870
+1984,4,1,marcopeereboom,2017-12-01 18:23:58,https://github.com/decred/politeia/issues/29#issuecomment-348570141
+1985,4,1,marcopeereboom,2017-12-01 18:24:15,https://github.com/decred/politeia/issues/39#issuecomment-348570227
+1986,4,1,marcopeereboom,2017-12-01 18:24:41,https://github.com/decred/politeia/issues/46#issuecomment-348570326
+1987,4,1,marcopeereboom,2017-12-01 18:24:59,https://github.com/decred/politeia/issues/18#issuecomment-348570397
+1988,4,1,marcopeereboom,2017-12-01 18:26:21,https://github.com/decred/politeia/issues/58#issuecomment-348570719
+1989,4,1,marcopeereboom,2017-12-01 18:26:41,https://github.com/decred/politeia/issues/83#issuecomment-348570812
+1990,4,1,marcopeereboom,2017-12-01 18:28:08,https://github.com/decred/politeia/issues/100#issuecomment-348571193
+1991,4,1,marcopeereboom,2017-12-01 18:37:34,https://github.com/decred/politeia/issues/86#issuecomment-348573625
+1992,4,1,marcopeereboom,2017-12-01 18:40:55,https://github.com/decred/politeia/issues/169#issuecomment-348574527
+1993,4,1,marcopeereboom,2017-12-01 19:18:40,https://github.com/decred/politeia/issues/161#issuecomment-348589159
+1994,4,1,rgeraldes,2017-12-03 22:10:57,https://github.com/decred/politeia/pull/156#issuecomment-348819472
+1995,4,1,sndurkin,2017-12-04 00:10:29,https://github.com/decred/politeia/issues/100#issuecomment-348832145
+1996,4,1,rgeraldes,2017-12-04 01:31:03,https://github.com/decred/politeia/issues/179#issuecomment-348838401
+1997,4,1,rgeraldes,2017-12-04 14:13:33,https://github.com/decred/politeia/pull/151#issuecomment-348973383
+1998,4,1,sndurkin,2017-12-05 16:12:07,https://github.com/decred/politeia/issues/167#issuecomment-349353591
+1999,4,1,marcopeereboom,2017-12-05 18:58:09,https://github.com/decred/politeia/issues/167#issuecomment-349405359
+2000,4,1,sndurkin,2017-12-07 15:26:19,https://github.com/decred/politeia/issues/186#issuecomment-350000272
+2001,4,1,marcopeereboom,2017-12-07 20:37:12,https://github.com/decred/politeia/pull/187#issuecomment-350086932
+2002,4,1,rgeraldes,2017-12-08 21:04:08,https://github.com/decred/politeia/pull/151#issuecomment-350371294
+2003,4,1,jolan,2017-12-11 20:09:00,https://github.com/decred/politeia/issues/100#issuecomment-350842917
+2004,4,1,jolan,2017-12-12 16:20:57,https://github.com/decred/politeia/pull/152#issuecomment-351102746
+2105,4,1,vctt94,2017-12-13 17:53:16,https://github.com/decred/politeia/pull/183#issuecomment-351469961
+2106,4,1,marcopeereboom,2017-12-13 18:04:08,https://github.com/decred/politeia/pull/183#issuecomment-351473091
+2107,4,1,vctt94,2017-12-13 18:26:08,https://github.com/decred/politeia/pull/183#issuecomment-351479069
+2108,4,1,marcopeereboom,2017-12-14 16:54:42,https://github.com/decred/politeia/pull/183#issuecomment-351770173
+2109,4,1,ultimatecrypto,2017-12-15 08:13:16,https://github.com/decred/politeia/pull/151#issuecomment-351941228
+2110,4,1,sndurkin,2017-12-15 20:44:32,https://github.com/decred/politeia/issues/193#issuecomment-352107404
+2111,4,1,marcopeereboom,2017-12-19 22:54:36,https://github.com/decred/politeia/pull/183#issuecomment-352911836
+2112,4,1,dajohi,2017-12-20 18:16:33,https://github.com/decred/politeia/pull/151#issuecomment-353141662
+2113,4,1,fernandoabolafio,2018-01-06 18:28:20,https://github.com/decred/politeia/pull/196#issuecomment-355765750
+2114,4,1,marcopeereboom,2018-01-08 15:46:07,https://github.com/decred/politeia/issues/193#issuecomment-356003467
+2115,4,1,marcopeereboom,2018-01-08 15:48:39,https://github.com/decred/politeia/issues/184#issuecomment-356004281
+2116,4,1,vctt94,2018-01-08 16:36:31,https://github.com/decred/politeia/issues/197#issuecomment-356019410
+2117,4,1,AlanL1,2018-01-10 07:02:00,https://github.com/decred/politeia/issues/199#issuecomment-356517290
+2118,4,1,fernandoabolafio,2018-01-15 16:27:33,https://github.com/decred/politeia/issues/207#issuecomment-357730659
+2119,4,1,sndurkin,2018-01-15 17:39:17,https://github.com/decred/politeia/pull/202#issuecomment-357748070
+2120,4,1,sndurkin,2018-01-16 03:37:22,https://github.com/decred/politeia/pull/202#issuecomment-357845349
+2121,4,1,fernandoabolafio,2018-01-16 15:37:28,https://github.com/decred/politeia/issues/210#issuecomment-358001362
+2122,4,1,AlanL1,2018-01-17 16:46:14,https://github.com/decred/politeia/issues/186#issuecomment-358366034
+2123,4,1,sndurkin,2018-01-21 05:55:53,https://github.com/decred/politeia/issues/208#issuecomment-359226093
+2124,4,1,fernandoabolafio,2018-01-21 14:54:31,https://github.com/decred/politeia/pull/215#issuecomment-359254124
+2125,4,1,fernandoabolafio,2018-01-21 15:20:46,https://github.com/decred/politeia/pull/214#issuecomment-359255890
+2126,4,1,fernandoabolafio,2018-01-22 13:35:10,https://github.com/decred/politeia/pull/216#issuecomment-359424620
+2127,4,1,fernandoabolafio,2018-01-22 13:45:45,https://github.com/decred/politeia/issues/213#issuecomment-359427256
+2128,4,1,AlanL1,2018-01-22 15:31:15,https://github.com/decred/politeia/issues/186#issuecomment-359458943
+2129,4,1,fernandoabolafio,2018-01-22 16:21:03,https://github.com/decred/politeia/pull/214#issuecomment-359478042
+2130,4,1,marcopeereboom,2018-01-23 14:33:28,https://github.com/decred/politeia/pull/214#issuecomment-359808621
+2131,4,1,vctt94,2018-01-26 17:47:11,https://github.com/decred/politeia/issues/100#issuecomment-360854699
+2132,4,1,AlanL1,2018-02-05 16:21:41,https://github.com/decred/politeia/pull/222#issuecomment-363135913
+2133,4,1,AlanL1,2018-02-06 08:29:44,https://github.com/decred/politeia/pull/222#issuecomment-363347297
+2134,4,1,AlanL1,2018-02-06 17:29:10,https://github.com/decred/politeia/pull/221#issuecomment-363500025
+2135,4,1,AlanL1,2018-02-09 10:01:54,https://github.com/decred/politeia/pull/221#issuecomment-364389536
+2136,4,1,AlanL1,2018-02-13 16:28:33,https://github.com/decred/politeia/pull/221#issuecomment-365321118
+2137,4,1,sndurkin,2018-02-13 21:10:23,https://github.com/decred/politeia/pull/221#issuecomment-365405193
+2138,4,1,vctt94,2018-02-19 18:23:24,https://github.com/decred/politeia/issues/217#issuecomment-366770977
+2139,4,1,sudoscript,2018-03-03 23:45:47,https://github.com/decred/politeia/pull/234#issuecomment-370189013
+2140,4,1,sudoscript,2018-03-11 20:08:55,https://github.com/decred/politeia/pull/234#issuecomment-372144928
+2141,4,1,marcopeereboom,2018-03-13 14:56:45,https://github.com/decred/politeia/issues/218#issuecomment-372694605
+2142,4,1,marcopeereboom,2018-03-20 18:56:56,https://github.com/decred/politeia/issues/193#issuecomment-374716871
+2143,4,1,marcopeereboom,2018-04-09 14:27:53,https://github.com/decred/politeia/pull/212#issuecomment-379771407
+2144,4,1,dajohi,2018-04-11 02:05:27,https://github.com/decred/politeia/pull/229#issuecomment-380302928
+2145,4,1,dajohi,2018-04-11 02:06:05,https://github.com/decred/politeia/pull/241#issuecomment-380303028
+2146,4,1,vctt94,2018-04-11 14:15:43,https://github.com/decred/politeia/pull/241#issuecomment-380467786
+2147,4,1,vctt94,2018-04-11 14:15:53,https://github.com/decred/politeia/pull/229#issuecomment-380467841
+2148,4,1,sudoscript,2018-04-11 18:08:05,https://github.com/decred/politeia/pull/241#issuecomment-380544765
+2149,4,1,vctt94,2018-04-12 13:58:16,https://github.com/decred/politeia/pull/241#issuecomment-380814542
+2150,4,1,marcopeereboom,2018-04-12 20:20:53,https://github.com/decred/politeia/pull/144#issuecomment-380932317
+2151,4,1,marcopeereboom,2018-04-12 20:21:18,https://github.com/decred/politeia/pull/151#issuecomment-380932448
+2152,4,1,sudoscript,2018-04-12 21:13:30,https://github.com/decred/politeia/pull/241#issuecomment-380946301
+2153,4,1,decebal,2018-04-16 22:27:35,https://github.com/decred/politeia/issues/225#issuecomment-381769959
+2154,4,1,vctt94,2018-04-17 13:34:58,https://github.com/decred/politeia/pull/251#issuecomment-381994333
+2155,4,1,marcopeereboom,2018-04-17 13:38:40,https://github.com/decred/politeia/pull/251#issuecomment-381995521
+2156,4,1,vctt94,2018-04-17 13:46:17,https://github.com/decred/politeia/pull/251#issuecomment-381998162
+2157,4,1,marcopeereboom,2018-04-17 17:58:07,https://github.com/decred/politeia/pull/251#issuecomment-382085545
+2158,4,1,marcopeereboom,2018-04-17 18:21:07,https://github.com/decred/politeia/pull/255#issuecomment-382092698
+2159,4,1,marcopeereboom,2018-04-20 18:44:52,https://github.com/decred/politeia/pull/260#issuecomment-383187545
+2160,4,1,marcopeereboom,2018-04-26 15:38:25,https://github.com/decred/politeia/pull/258#issuecomment-384687855
+2161,4,1,marcopeereboom,2018-04-26 15:39:09,https://github.com/decred/politeia/pull/257#issuecomment-384688163
+2162,4,1,dajohi,2018-04-26 19:09:41,https://github.com/decred/politeia/pull/257#issuecomment-384757286
+2163,4,1,vctt94,2018-04-30 13:23:50,https://github.com/decred/politeia/issues/261#issuecomment-385396729
+2164,4,1,marcopeereboom,2018-04-30 13:51:06,https://github.com/decred/politeia/issues/259#issuecomment-385403826
+2165,4,1,marcopeereboom,2018-04-30 14:46:23,https://github.com/decred/politeia/pull/245#issuecomment-385420750
+2166,4,1,marcopeereboom,2018-04-30 14:56:51,https://github.com/decred/politeia/issues/225#issuecomment-385424154
+2167,4,1,sndurkin,2018-05-01 17:17:22,https://github.com/decred/politeia/issues/266#issuecomment-385728964
+2168,4,1,sndurkin,2018-05-02 21:11:31,https://github.com/decred/politeia/issues/100#issuecomment-386122729
+2169,4,1,dajohi,2018-05-03 14:28:57,https://github.com/decred/politeia/pull/257#issuecomment-386314901
+2170,4,1,jrick,2018-05-08 13:34:03,https://github.com/decred/politeia/pull/272#issuecomment-387403680
+2171,4,1,EvertonMelo,2018-05-08 14:14:54,https://github.com/decred/politeia/pull/272#issuecomment-387417076
+2172,4,1,jrick,2018-05-08 14:24:12,https://github.com/decred/politeia/pull/272#issuecomment-387420162
+2173,4,1,EvertonMelo,2018-05-08 14:39:38,https://github.com/decred/politeia/pull/272#issuecomment-387425448
+2174,4,1,EvertonMelo,2018-05-08 14:45:39,https://github.com/decred/politeia/pull/272#issuecomment-387427542
+2175,4,1,marcopeereboom,2018-05-08 15:18:20,https://github.com/decred/politeia/pull/272#issuecomment-387438993
+2176,4,1,EvertonMelo,2018-05-08 18:08:45,https://github.com/decred/politeia/pull/272#issuecomment-387491991
+2177,4,1,sndurkin,2018-05-10 14:45:18,https://github.com/decred/politeia/pull/272#issuecomment-388075431
+2178,4,1,marcopeereboom,2018-05-10 15:53:58,https://github.com/decred/politeia/pull/277#issuecomment-388097037
+2179,4,1,EvertonMelo,2018-05-10 17:28:51,https://github.com/decred/politeia/pull/272#issuecomment-388124768
+2180,4,1,sndurkin,2018-05-10 18:20:09,https://github.com/decred/politeia/pull/279#issuecomment-388140072
+2181,4,1,sndurkin,2018-05-10 18:27:04,https://github.com/decred/politeia/pull/272#issuecomment-388142110
+2182,4,1,EvertonMelo,2018-05-10 20:50:40,https://github.com/decred/politeia/pull/272#issuecomment-388181643
+2183,4,1,marcopeereboom,2018-05-11 20:00:48,https://github.com/decred/politeia/pull/272#issuecomment-388470828
+2184,4,1,sndurkin,2018-05-17 02:54:44,https://github.com/decred/politeia/issues/287#issuecomment-389728603
+2185,4,1,sndurkin,2018-05-17 02:56:49,https://github.com/decred/politeia/issues/285#issuecomment-389728903
+2186,4,1,fernandoabolafio,2018-05-17 13:17:11,https://github.com/decred/politeia/issues/287#issuecomment-389862612
+2187,4,1,fernandoabolafio,2018-05-17 21:27:29,https://github.com/decred/politeia/pull/286#issuecomment-390017656
+2188,4,1,decebal,2018-05-18 18:25:25,https://github.com/decred/politeia/issues/264#issuecomment-390292567
+2189,4,1,decebal,2018-05-18 18:26:04,https://github.com/decred/politeia/issues/262#issuecomment-390292761
+2190,4,1,lte13,2018-05-21 07:08:53,https://github.com/decred/politeia/issues/265#issuecomment-390571874
+2191,4,1,marcopeereboom,2018-05-24 19:18:58,https://github.com/decred/politeia/pull/279#issuecomment-391828987
+2192,4,1,marcopeereboom,2018-05-25 20:53:24,https://github.com/decred/politeia/issues/295#issuecomment-392184387
+2193,4,1,marcopeereboom,2018-05-31 06:42:43,https://github.com/decred/politeia/pull/279#issuecomment-393424654
+2194,4,1,sndurkin,2018-05-31 19:29:12,https://github.com/decred/politeia/issues/265#issuecomment-393650312
+2195,4,1,lte13,2018-05-31 19:38:30,https://github.com/decred/politeia/issues/265#issuecomment-393653501
+2196,4,1,lte13,2018-06-02 05:53:52,https://github.com/decred/politeia/issues/306#issuecomment-394061205
+2197,4,1,lte13,2018-06-02 06:43:57,https://github.com/decred/politeia/issues/265#issuecomment-394063488
+2198,4,1,fernandoabolafio,2018-06-11 13:27:11,https://github.com/decred/politeia/issues/317#issuecomment-396242642
+2199,4,1,xaur,2018-06-11 18:18:12,https://github.com/decred/politeia/issues/97#issuecomment-396337207
+2200,4,1,sndurkin,2018-06-12 04:15:54,https://github.com/decred/politeia/pull/281#issuecomment-396460513
+2201,4,1,decebal,2018-06-12 14:57:21,https://github.com/decred/politeia/pull/281#issuecomment-396620287
+2202,4,1,sndurkin,2018-06-12 15:15:02,https://github.com/decred/politeia/pull/281#issuecomment-396626790
+2203,4,1,decebal,2018-06-13 10:44:27,https://github.com/decred/politeia/pull/281#issuecomment-396894747
+2204,4,1,fernandoabolafio,2018-06-13 18:57:16,https://github.com/decred/politeia/pull/320#issuecomment-397048457
+2205,4,1,tiagoalvesdulce,2018-06-15 15:41:31,https://github.com/decred/politeia/pull/328#issuecomment-397661224
+2206,4,1,lukebp,2018-06-15 19:38:32,https://github.com/decred/politeia/pull/292#issuecomment-397722578
+2207,4,1,tiagoalvesdulce,2018-06-18 14:39:10,https://github.com/decred/politeia/pull/328#issuecomment-398077135
+2208,4,1,marcopeereboom,2018-06-19 12:17:51,https://github.com/decred/politeia/pull/328#issuecomment-398378379
+2209,4,1,sndurkin,2018-06-21 17:55:14,https://github.com/decred/politeia/pull/338#issuecomment-399190429
+2210,4,1,lukebp,2018-06-21 21:53:45,https://github.com/decred/politeia/pull/292#issuecomment-399255468
+2211,4,1,sndurkin,2018-06-22 22:18:49,https://github.com/decred/politeia/issues/346#issuecomment-399597416
+2212,4,1,lukebp,2018-06-23 04:54:18,https://github.com/decred/politeia/issues/346#issuecomment-399631068
+2213,4,1,lukebp,2018-06-23 18:14:40,https://github.com/decred/politeia/issues/349#issuecomment-399698307
+2214,4,1,sndurkin,2018-06-24 20:02:18,https://github.com/decred/politeia/issues/349#issuecomment-399783450
+2215,4,1,chappjc,2018-06-26 16:37:24,https://github.com/decred/politeia/pull/337#issuecomment-400381355
+2216,4,1,chappjc,2018-06-29 18:12:42,https://github.com/decred/politeia/pull/337#issuecomment-401432586
+2217,4,1,marcopeereboom,2018-07-02 11:24:29,https://github.com/decred/politeia/pull/289#issuecomment-401773432
+2218,4,1,tiagoalvesdulce,2018-07-02 17:31:24,https://github.com/decred/politeia/issues/353#issuecomment-401877922
+2219,4,1,marcopeereboom,2018-07-03 10:38:20,https://github.com/decred/politeia/issues/346#issuecomment-402101992
+2220,4,1,marcopeereboom,2018-07-03 10:40:46,https://github.com/decred/politeia/issues/350#issuecomment-402102821
+2221,4,1,chappjc,2018-07-03 14:27:28,https://github.com/decred/politeia/pull/337#issuecomment-402176768
+2222,4,1,fernandoabolafio,2018-07-03 18:53:07,https://github.com/decred/politeia/pull/320#issuecomment-402258662
+2223,4,1,tiagoalvesdulce,2018-07-04 01:44:49,https://github.com/decred/politeia/issues/340#issuecomment-402338694
+2224,4,1,fernandoabolafio,2018-07-04 13:35:51,https://github.com/decred/politeia/issues/340#issuecomment-402481297
+2225,4,1,tiagoalvesdulce,2018-07-05 20:19:54,https://github.com/decred/politeia/issues/372#issuecomment-402840953
+2226,4,1,sndurkin,2018-07-06 15:41:03,https://github.com/decred/politeia/issues/372#issuecomment-403070742
+2227,4,1,fernandoabolafio,2018-07-06 15:52:15,https://github.com/decred/politeia/issues/372#issuecomment-403073601
+2228,4,1,sneurlax,2018-07-09 05:43:03,https://github.com/decred/politeia/issues/265#issuecomment-403365874
+2229,4,1,lukebp,2018-07-09 15:13:40,https://github.com/decred/politeia/issues/366#issuecomment-403514153
+2230,4,1,sndurkin,2018-07-10 03:17:47,https://github.com/decred/politeia/issues/366#issuecomment-403686760
+2231,4,1,lukebp,2018-07-10 16:18:33,https://github.com/decred/politeia/issues/366#issuecomment-403881883
+2232,4,1,dajohi,2018-07-11 20:09:43,https://github.com/decred/politeia/pull/378#issuecomment-404294596
+2233,4,1,lukebp,2018-07-13 15:13:35,https://github.com/decred/politeia/issues/366#issuecomment-404863257
+2234,4,1,vctt94,2018-07-14 16:30:58,https://github.com/decred/politeia/issues/384#issuecomment-405034399
+2235,4,1,sndurkin,2018-07-15 22:19:39,https://github.com/decred/politeia/issues/384#issuecomment-405122786
+2236,4,1,fernandoabolafio,2018-07-16 12:48:29,https://github.com/decred/politeia/issues/376#issuecomment-405236199
+2237,4,1,fernandoabolafio,2018-07-16 18:54:08,https://github.com/decred/politeia/issues/354#issuecomment-405344551
+2238,4,1,fernandoabolafio,2018-07-16 18:57:41,https://github.com/decred/politeia/issues/330#issuecomment-405345644
+2239,4,1,sumiflow,2018-07-17 19:51:14,https://github.com/decred/politeia/pull/390#issuecomment-405706243
+2240,4,1,sndurkin,2018-07-18 04:46:11,https://github.com/decred/politeia/pull/390#issuecomment-405807424
+2241,4,1,fernandoabolafio,2018-07-21 11:57:24,https://github.com/decred/politeia/pull/393#issuecomment-406790677
+2242,4,1,fernandoabolafio,2018-07-23 23:59:51,https://github.com/decred/politeia/pull/370#issuecomment-407237061
+2243,4,1,vctt94,2018-07-24 13:06:55,https://github.com/decred/politeia/pull/394#issuecomment-407399644
+2244,4,1,sndurkin,2018-07-26 14:21:23,https://github.com/decred/politeia/issues/399#issuecomment-408114016
+2245,4,1,lukebp,2018-07-26 18:42:22,https://github.com/decred/politeia/issues/399#issuecomment-408195778
+2246,4,1,lukebp,2018-07-28 16:00:43,https://github.com/decred/politeia/issues/399#issuecomment-408617507
+2247,4,1,sndurkin,2018-07-28 23:19:18,https://github.com/decred/politeia/issues/399#issuecomment-408640932
+2248,4,1,sndurkin,2018-07-30 15:21:17,https://github.com/decred/politeia/issues/377#issuecomment-408901931
+2249,4,1,tiagoalvesdulce,2018-07-30 15:56:54,https://github.com/decred/politeia/pull/393#issuecomment-408914722
+2250,4,1,tiagoalvesdulce,2018-07-30 18:10:07,https://github.com/decred/politeia/pull/393#issuecomment-408958003
+2251,4,1,tiagoalvesdulce,2018-07-30 19:30:40,https://github.com/decred/politeia/pull/393#issuecomment-408982541
+2252,4,1,fernandoabolafio,2018-07-30 20:06:58,https://github.com/decred/politeia/pull/393#issuecomment-408992838
+2253,4,1,fernandoabolafio,2018-08-01 13:10:44,https://github.com/decred/politeia/pull/393#issuecomment-409569134
+2254,4,1,sndurkin,2018-08-01 21:21:36,https://github.com/decred/politeia/pull/411#issuecomment-409727799
+2255,4,1,sndurkin,2018-08-02 04:06:28,https://github.com/decred/politeia/issues/225#issuecomment-409799334
+2256,4,1,sndurkin,2018-08-02 04:07:22,https://github.com/decred/politeia/issues/262#issuecomment-409799438
+2257,4,1,sndurkin,2018-08-02 04:10:57,https://github.com/decred/politeia/issues/83#issuecomment-409799870
+2258,4,1,fernandoabolafio,2018-08-02 13:09:57,https://github.com/decred/politeia/pull/393#issuecomment-409920317
+2259,4,1,lukebp,2018-08-06 12:41:25,https://github.com/decred/politeia/issues/310#issuecomment-410694455
+2260,4,1,lukebp,2018-08-08 12:02:38,https://github.com/decred/politeia/issues/368#issuecomment-411381571
+2261,4,1,sndurkin,2018-08-08 15:24:44,https://github.com/decred/politeia/issues/368#issuecomment-411446085
+2262,4,1,fernandoabolafio,2018-08-29 13:01:22,https://github.com/decred/politeia/issues/414#issuecomment-416943965
+2263,4,1,vctt94,2018-08-29 18:45:26,https://github.com/decred/politeia/issues/339#issuecomment-417062778
+2264,4,1,RichardRed0x,2018-08-30 09:03:11,https://github.com/decred/politeia/issues/339#issuecomment-417245438
+2265,4,1,fernandoabolafio,2018-08-30 16:08:18,https://github.com/decred/politeia/issues/427#issuecomment-417375087
+2266,4,1,fernandoabolafio,2018-08-30 16:08:47,https://github.com/decred/politeia/issues/298#issuecomment-417375210
+2267,4,1,marcopeereboom,2018-09-04 21:21:04,https://github.com/decred/politeia/issues/402#issuecomment-418522092
+2268,4,1,marcopeereboom,2018-09-04 21:26:57,https://github.com/decred/politeia/issues/101#issuecomment-418523653
+2269,4,1,marcopeereboom,2018-09-04 21:27:45,https://github.com/decred/politeia/issues/109#issuecomment-418523893
+2270,4,1,marcopeereboom,2018-09-04 21:28:55,https://github.com/decred/politeia/issues/145#issuecomment-418524213
+2271,4,1,marcopeereboom,2018-09-04 21:29:32,https://github.com/decred/politeia/issues/177#issuecomment-418524385
+2272,4,1,marcopeereboom,2018-09-04 21:29:41,https://github.com/decred/politeia/issues/179#issuecomment-418524427
+2273,4,1,marcopeereboom,2018-09-04 21:29:56,https://github.com/decred/politeia/issues/180#issuecomment-418524510
+2274,4,1,marcopeereboom,2018-09-04 21:36:42,https://github.com/decred/politeia/issues/264#issuecomment-418526223
+2275,4,1,marcopeereboom,2018-09-04 21:38:28,https://github.com/decred/politeia/issues/278#issuecomment-418526691
+2276,4,1,marcopeereboom,2018-09-04 21:39:21,https://github.com/decred/politeia/issues/324#issuecomment-418526907
+2277,4,1,marcopeereboom,2018-09-04 21:43:58,https://github.com/decred/politeia/issues/346#issuecomment-418528099
+2278,4,1,marcopeereboom,2018-09-04 21:44:41,https://github.com/decred/politeia/issues/355#issuecomment-418528273
+2279,4,1,marcopeereboom,2018-09-04 21:45:23,https://github.com/decred/politeia/issues/356#issuecomment-418528450
+2280,4,1,marcopeereboom,2018-09-04 21:47:15,https://github.com/decred/politeia/issues/403#issuecomment-418528922
+2281,4,1,RichardRed0x,2018-09-04 21:47:48,https://github.com/decred/politeia/issues/356#issuecomment-418529063
+2282,4,1,marcopeereboom,2018-09-04 21:48:10,https://github.com/decred/politeia/issues/380#issuecomment-418529152
+2283,4,1,marcopeereboom,2018-09-04 21:48:38,https://github.com/decred/politeia/issues/379#issuecomment-418529269
+2284,4,1,marcopeereboom,2018-09-04 21:49:09,https://github.com/decred/politeia/issues/372#issuecomment-418529382
+2285,4,1,marcopeereboom,2018-09-04 21:50:42,https://github.com/decred/politeia/issues/356#issuecomment-418529788
+2286,4,1,marcopeereboom,2018-09-04 21:52:11,https://github.com/decred/politeia/issues/324#issuecomment-418530181
+2287,4,1,lukebp,2018-09-05 00:08:43,https://github.com/decred/politeia/issues/441#issuecomment-418556834
+2288,4,1,fernandoabolafio,2018-09-05 12:46:32,https://github.com/decred/politeia/pull/370#issuecomment-418717294
+2289,4,1,fernandoabolafio,2018-09-05 12:48:07,https://github.com/decred/politeia/pull/322#issuecomment-418717805
+2290,4,1,marcopeereboom,2018-09-05 16:36:29,https://github.com/decred/politeia/issues/213#issuecomment-418797257
+2291,4,1,marcopeereboom,2018-09-06 13:34:33,https://github.com/decred/politeia/issues/454#issuecomment-419095186
+2292,4,1,lukebp,2018-09-06 13:56:10,https://github.com/decred/politeia/issues/453#issuecomment-419102683
+2293,4,1,fernandoabolafio,2018-09-06 16:44:43,https://github.com/decred/politeia/issues/265#issuecomment-419162935
+2294,4,1,marcopeereboom,2018-09-10 18:53:56,https://github.com/decred/politeia/issues/462#issuecomment-420021606
+2295,4,1,tiagoalvesdulce,2018-09-10 19:08:36,https://github.com/decred/politeia/issues/462#issuecomment-420025892
+2296,4,1,thi4go,2018-09-11 12:45:32,https://github.com/decred/politeia/issues/463#issuecomment-420261157
+2297,4,1,marcopeereboom,2018-09-11 18:25:32,https://github.com/decred/politeia/issues/450#issuecomment-420372735
+2298,4,1,marcopeereboom,2018-09-13 15:04:37,https://github.com/decred/politeia/issues/463#issuecomment-421040255
+2299,4,1,lukebp,2018-09-14 13:41:46,https://github.com/decred/politeia/pull/423#issuecomment-421362098
+2300,4,1,lukebp,2018-09-19 17:08:40,https://github.com/decred/politeia/pull/467#issuecomment-422882736
+2301,4,1,lukebp,2018-09-20 13:24:09,https://github.com/decred/politeia/issues/444#issuecomment-423181518
+2302,4,1,lukebp,2018-09-20 13:24:54,https://github.com/decred/politeia/issues/447#issuecomment-423181764
+2303,4,1,lukebp,2018-09-20 14:24:53,https://github.com/decred/politeia/issues/449#issuecomment-423203105
+2304,4,1,lukebp,2018-09-21 13:10:56,https://github.com/decred/politeia/issues/448#issuecomment-423525622
+2305,4,1,lukebp,2018-09-24 13:22:13,https://github.com/decred/politeia/issues/478#issuecomment-423972329
+2306,4,1,lukebp,2018-09-25 15:34:13,https://github.com/decred/politeia/issues/478#issuecomment-424392344
+2307,4,1,degeri,2018-09-25 15:57:29,https://github.com/decred/politeia/issues/478#issuecomment-424401222
+2308,4,1,lukebp,2018-09-25 20:03:36,https://github.com/decred/politeia/pull/475#issuecomment-424481825
+2309,4,1,lukebp,2018-09-25 20:08:02,https://github.com/decred/politeia/issues/479#issuecomment-424483208
+2310,4,1,marcopeereboom,2018-09-26 21:53:06,https://github.com/decred/politeia/issues/461#issuecomment-424882219
+2311,4,1,wallclockbuilder,2018-09-28 17:53:40,https://github.com/decred/politeia/issues/474#issuecomment-425516114
+2312,4,1,wallclockbuilder,2018-09-28 17:57:03,https://github.com/decred/politeia/issues/474#issuecomment-425517127
+2313,4,1,fernandoabolafio,2018-09-28 21:37:27,https://github.com/decred/politeia/pull/492#issuecomment-425573274
+2314,4,1,lukebp,2018-09-29 23:37:54,https://github.com/decred/politeia/issues/474#issuecomment-425682366
+2315,4,1,lukebp,2018-09-30 20:51:30,https://github.com/decred/politeia/issues/456#issuecomment-425751084
+2316,4,1,wallclockbuilder,2018-10-01 04:49:10,https://github.com/decred/politeia/issues/474#issuecomment-425788569
+2317,4,1,fernandoabolafio,2018-10-01 15:42:52,https://github.com/decred/politeia/pull/491#issuecomment-425956024
+2318,4,1,fernandoabolafio,2018-10-01 15:43:17,https://github.com/decred/politeia/pull/465#issuecomment-425956173
+2319,4,1,thi4go,2018-10-01 18:39:44,https://github.com/decred/politeia/issues/490#issuecomment-426016902
+2320,4,1,sndurkin,2018-10-01 19:19:10,https://github.com/decred/politeia/issues/490#issuecomment-426029910
+2321,4,1,thi4go,2018-10-01 19:23:34,https://github.com/decred/politeia/issues/490#issuecomment-426031264
+2322,4,1,sndurkin,2018-10-01 19:30:41,https://github.com/decred/politeia/issues/490#issuecomment-426033530
+2323,4,1,wallclockbuilder,2018-10-01 22:18:09,https://github.com/decred/politeia/pull/494#issuecomment-426082957
+2324,4,1,wallclockbuilder,2018-10-01 23:13:44,https://github.com/decred/politeia/pull/494#issuecomment-426094503
+2325,4,1,sndurkin,2018-10-01 23:44:03,https://github.com/decred/politeia/pull/494#issuecomment-426099735
+2326,4,1,lukebp,2018-10-02 16:51:42,https://github.com/decred/politeia/pull/494#issuecomment-426348389
+2327,4,1,wallclockbuilder,2018-10-03 18:00:13,https://github.com/decred/politeia/pull/494#issuecomment-426735965
+2328,4,1,thi4go,2018-10-03 19:17:16,https://github.com/decred/politeia/issues/265#issuecomment-426764352
+2329,4,1,wallclockbuilder,2018-10-04 16:08:08,https://github.com/decred/politeia/pull/494#issuecomment-427076931
+2330,4,1,tiagoalvesdulce,2018-10-05 12:57:28,https://github.com/decred/politeia/pull/504#issuecomment-427357075
+2331,4,1,chappjc,2018-10-05 21:39:42,https://github.com/decred/politeia/issues/509#issuecomment-427506352
+2332,4,1,thi4go,2018-10-11 12:52:42,https://github.com/decred/politeia/pull/515#issuecomment-428943374
+2333,4,1,lukebp,2018-10-11 22:11:03,https://github.com/decred/politeia/issues/509#issuecomment-429136372
+2334,4,1,dajohi,2018-10-15 14:54:32,https://github.com/decred/politeia/pull/494#issuecomment-429886355
+2335,4,1,marcopeereboom,2018-10-16 18:33:37,https://github.com/decred/politeia/issues/486#issuecomment-430348521
+2336,4,1,marcopeereboom,2018-10-16 19:33:37,https://github.com/decred/politeia/issues/463#issuecomment-430370073
+2337,4,1,wallclockbuilder,2018-10-16 21:43:53,https://github.com/decred/politeia/pull/494#issuecomment-430411878
+2338,4,1,lukebp,2018-10-17 15:21:59,https://github.com/decred/politeia/pull/494#issuecomment-430672554
+2339,4,1,marcopeereboom,2018-10-17 19:27:51,https://github.com/decred/politeia/issues/508#issuecomment-430757694
+2340,4,1,wallclockbuilder,2018-10-17 22:51:37,https://github.com/decred/politeia/pull/494#issuecomment-430816599
+2341,4,1,xaur,2018-10-18 11:48:48,https://github.com/decred/politeia/issues/537#issuecomment-430978388
+2342,4,1,sndurkin,2018-10-18 17:00:00,https://github.com/decred/politeia/issues/537#issuecomment-431085787
+2343,4,1,matheusd,2018-10-18 18:44:53,https://github.com/decred/politeia/issues/544#issuecomment-431119360
+2344,4,1,marcopeereboom,2018-10-18 19:04:50,https://github.com/decred/politeia/issues/265#issuecomment-431125684
+2345,4,1,marcopeereboom,2018-10-18 19:07:41,https://github.com/decred/politeia/issues/350#issuecomment-431126570
+2346,4,1,marcopeereboom,2018-10-18 19:08:47,https://github.com/decred/politeia/issues/380#issuecomment-431126904
+2347,4,1,xaur,2018-10-19 07:47:25,https://github.com/decred/politeia/issues/537#issuecomment-431275546
+2348,4,1,sndurkin,2018-10-19 11:34:12,https://github.com/decred/politeia/issues/537#issuecomment-431333794
+2349,4,1,xaur,2018-10-21 11:48:40,https://github.com/decred/politeia/issues/456#issuecomment-431662311
+2350,4,1,sndurkin,2018-10-23 03:53:09,https://github.com/decred/politeia/pull/430#issuecomment-432081115
+2351,4,1,xaur,2018-10-23 11:09:54,https://github.com/decred/politeia/issues/544#issuecomment-432203312
+2352,4,1,vctt94,2018-10-23 13:00:04,https://github.com/decred/politeia/pull/430#issuecomment-432236538
+2353,4,1,lukebp,2018-10-23 16:30:45,https://github.com/decred/politeia/issues/555#issuecomment-432321840
+2354,4,1,lukebp,2018-10-23 16:45:26,https://github.com/decred/politeia/issues/555#issuecomment-432327001
+2355,4,1,fernandoabolafio,2018-10-23 16:49:03,https://github.com/decred/politeia/issues/555#issuecomment-432328258
+2356,4,1,matheusd,2018-10-23 18:57:43,https://github.com/decred/politeia/issues/544#issuecomment-432376112
+2357,4,1,degeri,2018-10-24 05:42:30,https://github.com/decred/politeia/pull/557#issuecomment-432520139
+2358,4,1,xaur,2018-10-25 13:53:51,https://github.com/decred/politeia/issues/546#issuecomment-433060093
+2359,4,1,xaur,2018-10-25 13:54:59,https://github.com/decred/politeia/issues/554#issuecomment-433060558
+2360,4,1,xaur,2018-10-25 21:05:03,https://github.com/decred/politeia/issues/554#issuecomment-433205363
+2361,4,1,fernandoabolafio,2018-10-26 15:33:23,https://github.com/decred/politeia/issues/561#issuecomment-433449128
+2362,4,1,davecgh,2018-10-27 01:51:17,https://github.com/decred/politeia/issues/562#issuecomment-433581718
+2363,4,1,degeri,2018-10-29 16:12:48,https://github.com/decred/politeia/issues/561#issuecomment-433972614
+2364,4,1,xaur,2018-10-29 19:38:41,https://github.com/decred/politeia/issues/565#issuecomment-434050254
+2365,4,1,xaur,2018-10-30 15:01:16,https://github.com/decred/politeia/issues/558#issuecomment-434336313
+2366,4,1,xaur,2018-10-30 15:27:32,https://github.com/decred/politeia/issues/558#issuecomment-434347038
+2367,4,1,fernandoabolafio,2018-10-30 20:30:02,https://github.com/decred/politeia/pull/393#issuecomment-434457835
+2368,4,1,xaur,2018-10-31 13:50:00,https://github.com/decred/politeia/issues/558#issuecomment-434694046
+2369,4,1,davecgh,2018-11-01 20:00:51,https://github.com/decred/politeia/pull/566#issuecomment-435167637
+2370,4,1,xaur,2018-11-02 14:16:32,https://github.com/decred/politeia/issues/539#issuecomment-435394100
+2371,4,1,xaur,2018-11-02 15:15:32,https://github.com/decred/politeia/issues/535#issuecomment-435413219
+2372,4,1,sndurkin,2018-11-02 16:20:55,https://github.com/decred/politeia/issues/535#issuecomment-435434280
+2373,4,1,sndurkin,2018-11-03 12:59:35,https://github.com/decred/politeia/pull/577#issuecomment-435586087
+2374,4,1,xaur,2018-11-03 13:30:54,https://github.com/decred/politeia/issues/535#issuecomment-435588186
+2375,4,1,sndurkin,2018-11-03 13:47:38,https://github.com/decred/politeia/issues/535#issuecomment-435589218
+2376,4,1,xaur,2018-11-04 10:09:23,https://github.com/decred/politeia/issues/535#issuecomment-435656995
+2377,4,1,raedah,2018-11-04 16:14:42,https://github.com/decred/politeia/issues/567#issuecomment-435682802
+2378,4,1,sndurkin,2018-11-06 04:05:45,https://github.com/decred/politeia/pull/577#issuecomment-436124456
+2379,4,1,lukebp,2018-11-06 12:50:24,https://github.com/decred/politeia/pull/581#issuecomment-436241366
+2380,4,1,thi4go,2018-11-06 12:53:04,https://github.com/decred/politeia/issues/580#issuecomment-436242114
+2381,4,1,xaur,2018-11-07 21:26:05,https://github.com/decred/politeia/issues/582#issuecomment-436783012
+2382,4,1,xaur,2018-11-07 21:30:19,https://github.com/decred/politeia/issues/582#issuecomment-436784226
+2383,4,1,xaur,2018-11-11 15:09:37,https://github.com/decred/politeia/issues/591#issuecomment-437678234
+2384,4,1,xaur,2018-11-11 15:48:21,https://github.com/decred/politeia/issues/591#issuecomment-437681156
+2385,4,1,RichardRed0x,2018-11-11 17:23:32,https://github.com/decred/politeia/issues/591#issuecomment-437688033
+2386,4,1,RichardRed0x,2018-11-11 17:29:26,https://github.com/decred/politeia/issues/591#issuecomment-437688501
+2387,4,1,xaur,2018-11-11 20:08:16,https://github.com/decred/politeia/issues/590#issuecomment-437700427
+2388,4,1,jzbz,2018-11-11 20:46:24,https://github.com/decred/politeia/issues/590#issuecomment-437703285
+2389,4,1,xaur,2018-11-11 21:48:42,https://github.com/decred/politeia/issues/590#issuecomment-437708130
+2390,4,1,xaur,2018-11-11 21:57:02,https://github.com/decred/politeia/issues/479#issuecomment-437708741
+2391,4,1,jzbz,2018-11-11 22:03:28,https://github.com/decred/politeia/issues/590#issuecomment-437709238
+2392,4,1,xaur,2018-11-11 23:28:52,https://github.com/decred/politeia/issues/590#issuecomment-437715586
+2393,4,1,lukebp,2018-11-14 22:09:10,https://github.com/decred/politeia/issues/563#issuecomment-438837196
+2394,4,1,degeri,2018-11-15 06:42:57,https://github.com/decred/politeia/issues/563#issuecomment-438935148
+2395,4,1,marcopeereboom,2018-11-15 19:22:48,https://github.com/decred/politeia/issues/593#issuecomment-439159403
+2396,4,1,lukebp,2018-11-15 20:30:59,https://github.com/decred/politeia/pull/595#issuecomment-439179830
+2397,4,1,thi4go,2018-11-15 20:45:58,https://github.com/decred/politeia/issues/561#issuecomment-439184023
+2398,4,1,xaur,2018-11-16 07:19:50,https://github.com/decred/politeia/issues/593#issuecomment-439304232
+2399,4,1,xaur,2018-11-16 07:45:10,https://github.com/decred/politeia/issues/590#issuecomment-439308982
+2400,4,1,degeri,2018-11-17 02:57:49,https://github.com/decred/politeia/issues/563#issuecomment-439582431
+2401,4,1,victorgcramos,2018-11-18 02:38:12,https://github.com/decred/politeia/pull/606#issuecomment-439663091
+2402,4,1,victorgcramos,2018-11-18 02:44:01,https://github.com/decred/politeia/pull/606#issuecomment-439663298
+2403,4,1,lukebp,2018-11-19 13:56:16,https://github.com/decred/politeia/issues/608#issuecomment-439900649
+2404,4,1,degeri,2018-11-19 14:15:21,https://github.com/decred/politeia/issues/608#issuecomment-439906487
+2405,4,1,degeri,2018-11-20 04:31:29,https://github.com/decred/politeia/issues/611#issuecomment-440134416
+2406,4,1,fernandoabolafio,2018-11-20 18:18:58,https://github.com/decred/politeia/issues/612#issuecomment-440378680
+2407,4,1,marcopeereboom,2018-11-20 19:38:55,https://github.com/decred/politeia/issues/590#issuecomment-440404048
+2408,4,1,jzbz,2018-11-20 19:40:23,https://github.com/decred/politeia/issues/590#issuecomment-440404491
+2409,4,1,fernandoabolafio,2018-11-21 17:07:01,https://github.com/decred/politeia/pull/610#issuecomment-440741240
+2410,4,1,victorgcramos,2018-11-21 17:33:16,https://github.com/decred/politeia/pull/606#issuecomment-440750057
+2411,4,1,lukebp,2018-11-21 18:37:59,https://github.com/decred/politeia/pull/610#issuecomment-440769394
+2412,4,1,fernandoabolafio,2018-11-22 14:54:33,https://github.com/decred/politeia/pull/613#issuecomment-441053831
+2413,4,1,lukebp,2018-11-26 12:02:38,https://github.com/decred/politeia/issues/585#issuecomment-441615668
+2414,4,1,lukebp,2018-11-26 12:34:53,https://github.com/decred/politeia/issues/607#issuecomment-441623670
+2415,4,1,lukebp,2018-11-26 12:44:35,https://github.com/decred/politeia/issues/474#issuecomment-441626189
+2416,4,1,lukebp,2018-11-26 12:46:25,https://github.com/decred/politeia/issues/355#issuecomment-441626670
+2417,4,1,degeri,2018-11-26 12:49:11,https://github.com/decred/politeia/issues/607#issuecomment-441627425
+2418,4,1,s-ben,2018-11-26 22:24:42,https://github.com/decred/politeia/issues/474#issuecomment-441823430
+2419,4,1,lukebp,2018-11-27 00:11:22,https://github.com/decred/politeia/issues/619#issuecomment-441848628
+2420,4,1,s-ben,2018-11-28 22:22:19,https://github.com/decred/politeia/issues/474#issuecomment-442627702
+2421,4,1,thi4go,2018-11-28 23:10:41,https://github.com/decred/politeia/pull/617#issuecomment-442641204
+2422,4,1,victorgcramos,2018-11-29 14:42:36,https://github.com/decred/politeia/issues/622#issuecomment-442857931
+2423,4,1,lukebp,2018-11-29 15:05:16,https://github.com/decred/politeia/issues/607#issuecomment-442866241
+2424,4,1,degeri,2018-11-29 15:09:05,https://github.com/decred/politeia/issues/607#issuecomment-442867675
+2425,4,1,lukebp,2018-11-29 16:39:41,https://github.com/decred/politeia/issues/474#issuecomment-442903686
+2426,4,1,lukebp,2018-11-29 21:48:45,https://github.com/decred/politeia/issues/607#issuecomment-443005853
+2427,4,1,lukebp,2018-11-30 01:34:45,https://github.com/decred/politeia/pull/589#issuecomment-443058614
+2428,4,1,xaur,2018-11-30 11:11:15,https://github.com/decred/politeia/issues/362#issuecomment-443171866
+2429,4,1,camus-code,2018-12-03 13:56:17,https://github.com/decred/politeia/issues/629#issuecomment-443718000
+2430,4,1,degeri,2018-12-03 16:43:32,https://github.com/decred/politeia/pull/633#issuecomment-443778718
+2431,4,1,camus-code,2018-12-03 20:16:51,https://github.com/decred/politeia/issues/621#issuecomment-443854696
+2432,4,1,degeri,2018-12-04 01:58:07,https://github.com/decred/politeia/pull/633#issuecomment-443940813
+2433,4,1,lukebp,2018-12-04 12:25:13,https://github.com/decred/politeia/pull/633#issuecomment-444082345
+2434,4,1,lukebp,2018-12-05 12:38:02,https://github.com/decred/politeia/issues/546#issuecomment-444470809
+2435,4,1,lukebp,2018-12-05 12:51:59,https://github.com/decred/politeia/issues/545#issuecomment-444474502
+2436,4,1,chappjc,2018-12-05 21:21:40,https://github.com/decred/politeia/issues/546#issuecomment-444653257
+2437,4,1,lukebp,2018-12-06 11:46:09,https://github.com/decred/politeia/issues/546#issuecomment-444844997
+2438,4,1,lukebp,2018-12-07 11:55:13,https://github.com/decred/politeia/pull/634#issuecomment-445210825
+2439,4,1,thi4go,2018-12-07 14:08:12,https://github.com/decred/politeia/issues/627#issuecomment-445243018
+2440,4,1,thi4go,2018-12-07 14:08:54,https://github.com/decred/politeia/issues/630#issuecomment-445243224
+2441,4,1,lukebp,2018-12-09 23:10:06,https://github.com/decred/politeia/issues/582#issuecomment-445580952
+2442,4,1,lukebp,2018-12-09 23:13:11,https://github.com/decred/politeia/issues/567#issuecomment-445581341
+2443,4,1,lukebp,2018-12-09 23:16:16,https://github.com/decred/politeia/issues/534#issuecomment-445582117
+2444,4,1,fernandoabolafio,2018-12-11 18:39:45,https://github.com/decred/politeia/issues/605#issuecomment-446313145
+2445,4,1,dajohi,2018-12-11 18:51:13,https://github.com/decred/politeia/issues/605#issuecomment-446317106
+2446,4,1,fernandoabolafio,2018-12-11 19:17:58,https://github.com/decred/politeia/issues/605#issuecomment-446326588
+2447,4,1,s-ben,2018-12-13 07:50:59,https://github.com/decred/politeia/pull/640#issuecomment-446873806
+2448,4,1,s-ben,2018-12-13 23:46:28,https://github.com/decred/politeia/issues/642#issuecomment-447162394
+2449,4,1,camus-code,2018-12-18 17:31:51,https://github.com/decred/politeia/issues/560#issuecomment-448303478
+2450,4,1,thi4go,2018-12-18 19:28:48,https://github.com/decred/politeia/issues/522#issuecomment-448340711
+2451,4,1,xaur,2018-12-18 20:58:58,https://github.com/decred/politeia/issues/560#issuecomment-448368034
+2452,4,1,lukebp,2018-12-19 12:27:03,https://github.com/decred/politeia/pull/633#issuecomment-448577875
+2453,4,1,lemonkabir,2018-12-19 17:22:23,https://github.com/decred/politeia/issues/647#issuecomment-448676305
+2454,4,1,lemonkabir,2018-12-19 17:23:41,https://github.com/decred/politeia/issues/647#issuecomment-448676743
+2455,4,1,degeri,2018-12-19 17:30:56,https://github.com/decred/politeia/issues/647#issuecomment-448679272
+2456,4,1,lemonkabir,2018-12-19 17:39:45,https://github.com/decred/politeia/issues/647#issuecomment-448682051
+2457,4,1,lemonkabir,2018-12-21 14:14:58,https://github.com/decred/politeia/issues/647#issuecomment-449399222
+2458,4,1,lemonkabir,2018-12-22 14:57:13,https://github.com/decred/politeia/issues/647#issuecomment-449575935
+2459,4,1,degeri,2018-12-22 15:06:25,https://github.com/decred/politeia/issues/647#issuecomment-449576544
+2460,4,1,lemonkabir,2018-12-22 15:08:30,https://github.com/decred/politeia/issues/647#issuecomment-449576693
+2461,4,1,degeri,2018-12-22 15:17:42,https://github.com/decred/politeia/issues/647#issuecomment-449577313
+2462,4,1,lemonkabir,2018-12-22 15:18:47,https://github.com/decred/politeia/issues/647#issuecomment-449577389
+2463,4,1,degeri,2018-12-22 19:20:54,https://github.com/decred/politeia/issues/651#issuecomment-449592343
+2464,4,1,degeri,2018-12-22 19:22:04,https://github.com/decred/politeia/issues/652#issuecomment-449592409
+2465,4,1,tpkeeper,2018-12-26 11:03:38,https://github.com/decred/politeia/issues/653#issuecomment-449950348
+2466,4,1,xaur,2018-12-26 14:09:32,https://github.com/decred/politeia/issues/647#issuecomment-449971638
+2467,4,1,lemonkabir,2018-12-26 14:15:53,https://github.com/decred/politeia/issues/650#issuecomment-449972418
+2468,4,1,thi4go,2018-12-26 16:12:44,https://github.com/decred/politeia/pull/655#issuecomment-449987734
+2469,4,1,xaur,2018-12-26 16:19:39,https://github.com/decred/politeia/issues/560#issuecomment-449988572
+2470,4,1,fernandoabolafio,2018-12-26 16:44:01,https://github.com/decred/politeia/issues/654#issuecomment-449991819
+2471,4,1,fernandoabolafio,2018-12-26 16:44:24,https://github.com/decred/politeia/pull/655#issuecomment-449991872
+2472,4,1,fernandoabolafio,2018-12-26 17:01:58,https://github.com/decred/politeia/issues/647#issuecomment-449994110
+2473,4,1,lukebp,2018-12-27 14:56:37,https://github.com/decred/politeia/issues/647#issuecomment-450165462
+2474,4,1,lemonkabir,2018-12-27 15:15:17,https://github.com/decred/politeia/issues/647#issuecomment-450169144
+2475,4,1,degeri,2018-12-27 16:27:00,https://github.com/decred/politeia/issues/657#issuecomment-450184407
+2476,4,1,lemonkabir,2018-12-27 16:43:15,https://github.com/decred/politeia/issues/657#issuecomment-450187710
+2477,4,1,thi4go,2018-12-27 16:57:27,https://github.com/decred/politeia/pull/649#issuecomment-450190667
+2478,4,1,camus-code,2018-12-27 19:06:53,https://github.com/decred/politeia/issues/560#issuecomment-450211706
+2479,4,1,xaur,2018-12-27 20:37:33,https://github.com/decred/politeia/issues/560#issuecomment-450226799
+2480,4,1,camus-code,2018-12-27 21:57:37,https://github.com/decred/politeia/issues/560#issuecomment-450238232
+2481,4,1,fernandoabolafio,2019-01-02 14:27:22,https://github.com/decred/politeia/issues/647#issuecomment-450876474
+2482,4,1,lemonkabir,2019-01-02 14:33:15,https://github.com/decred/politeia/issues/647#issuecomment-450877891
+2483,4,1,degeri,2019-01-02 14:34:43,https://github.com/decred/politeia/issues/647#issuecomment-450878248
+2484,4,1,thi4go,2019-01-05 14:59:17,https://github.com/decred/politeia/pull/644#issuecomment-451662703
+2485,4,1,lukebp,2019-01-07 15:31:45,https://github.com/decred/politeia/issues/661#issuecomment-451973085
+2486,4,1,degeri,2019-01-07 15:32:14,https://github.com/decred/politeia/issues/661#issuecomment-451973261
+2487,4,1,victorgcramos,2019-01-08 15:20:11,https://github.com/decred/politeia/pull/663#issuecomment-452335787
+2488,4,1,lukebp,2019-01-08 17:02:58,https://github.com/decred/politeia/pull/663#issuecomment-452374647
+2489,4,1,raedah,2019-01-08 22:49:38,https://github.com/decred/politeia/issues/664#issuecomment-452480315
+2490,4,1,marcopeereboom,2019-01-09 19:09:47,https://github.com/decred/politeia/issues/545#issuecomment-452819111
+2491,4,1,degeri,2019-01-10 18:17:45,https://github.com/decred/politeia/issues/666#issuecomment-453198865
+2492,4,1,lemonkabir,2019-01-10 18:21:18,https://github.com/decred/politeia/issues/666#issuecomment-453200060
+2493,4,1,degeri,2019-01-10 18:24:40,https://github.com/decred/politeia/issues/666#issuecomment-453201223
+2494,4,1,lemonkabir,2019-01-10 18:27:05,https://github.com/decred/politeia/issues/666#issuecomment-453202091
+2495,4,1,degeri,2019-01-10 18:32:43,https://github.com/decred/politeia/issues/666#issuecomment-453203874
+2496,4,1,lukebp,2019-01-10 18:36:00,https://github.com/decred/politeia/issues/666#issuecomment-453204931
+2497,4,1,fernandoabolafio,2019-01-11 16:21:08,https://github.com/decred/politeia/issues/560#issuecomment-453571884
+2498,4,1,xaur,2019-01-11 20:34:37,https://github.com/decred/politeia/issues/560#issuecomment-453648637
+2499,4,1,xaur,2019-01-13 17:34:03,https://github.com/decred/politeia/issues/664#issuecomment-453849450
+2500,4,1,degeri,2019-01-13 17:38:47,https://github.com/decred/politeia/issues/664#issuecomment-453849860
+2501,4,1,camus-code,2019-01-13 17:53:34,https://github.com/decred/politeia/issues/662#issuecomment-453851019
+2502,4,1,xaur,2019-01-13 19:04:40,https://github.com/decred/politeia/issues/662#issuecomment-453856427
+2503,4,1,sndurkin,2019-01-14 04:17:31,https://github.com/decred/politeia/pull/660#issuecomment-453898992
+2504,4,1,lukebp,2019-01-14 11:32:23,https://github.com/decred/politeia/pull/660#issuecomment-453975373
+2505,4,1,lukebp,2019-01-14 11:59:16,https://github.com/decred/politeia/issues/662#issuecomment-453981564
+2506,4,1,lukebp,2019-01-14 12:13:10,https://github.com/decred/politeia/issues/560#issuecomment-453984861
+2507,4,1,xaur,2019-01-15 10:09:20,https://github.com/decred/politeia/issues/560#issuecomment-454336905
+2508,4,1,lukebp,2019-01-15 14:21:50,https://github.com/decred/politeia/issues/560#issuecomment-454408319
+2509,4,1,dajohi,2019-01-16 19:08:08,https://github.com/decred/politeia/issues/669#issuecomment-454901206
+2510,4,1,camus-code,2019-01-16 19:17:38,https://github.com/decred/politeia/issues/662#issuecomment-454904460
+2511,4,1,xaur,2019-01-17 09:06:15,https://github.com/decred/politeia/issues/560#issuecomment-455095472
+2512,4,1,xaur,2019-01-21 13:54:54,https://github.com/decred/politeia/issues/662#issuecomment-456081952
+2513,4,1,camus-code,2019-01-21 21:01:45,https://github.com/decred/politeia/issues/662#issuecomment-456197836
+2514,4,1,lukebp,2019-01-21 21:21:36,https://github.com/decred/politeia/pull/644#issuecomment-456202045
+2515,4,1,camus-code,2019-01-21 21:43:35,https://github.com/decred/politeia/pull/671#issuecomment-456206367
+2516,4,1,xaur,2019-01-22 10:44:46,https://github.com/decred/politeia/issues/662#issuecomment-456354140
+2517,4,1,thi4go,2019-01-22 18:22:56,https://github.com/decred/politeia/issues/673#issuecomment-456507594
+2518,4,1,camus-code,2019-01-23 18:20:37,https://github.com/decred/politeia/issues/656#issuecomment-456911092
+2519,4,1,camus-code,2019-01-23 22:04:43,https://github.com/decred/politeia/issues/569#issuecomment-456984577
+2520,4,1,thi4go,2019-01-24 10:56:36,https://github.com/decred/politeia/pull/644#issuecomment-457155682
+2521,4,1,lukebp,2019-01-24 11:57:11,https://github.com/decred/politeia/pull/644#issuecomment-457171562
+2522,4,1,orthomind,2019-01-25 04:10:14,https://github.com/decred/politeia/issues/544#issuecomment-457449231
+2523,4,1,RichardRed0x,2019-01-27 00:27:55,https://github.com/decred/politeia/issues/678#issuecomment-457878206
+2524,4,1,s-ben,2019-01-28 20:17:05,https://github.com/decred/politeia/pull/677#issuecomment-458284980
+2525,4,1,lukebp,2019-01-28 21:02:35,https://github.com/decred/politeia/pull/677#issuecomment-458299931
+2526,4,1,s-ben,2019-01-28 21:27:25,https://github.com/decred/politeia/pull/677#issuecomment-458308101
+2527,4,1,lukebp,2019-01-30 13:51:17,https://github.com/decred/politeia/issues/678#issuecomment-458950463
+2528,4,1,linnutee,2019-01-30 16:42:52,https://github.com/decred/politeia/issues/678#issuecomment-459016121
+2529,4,1,lukebp,2019-01-30 18:23:01,https://github.com/decred/politeia/issues/678#issuecomment-459053005
+2530,4,1,s-ben,2019-01-30 22:02:38,https://github.com/decred/politeia/pull/677#issuecomment-459127539
+2531,4,1,xaur,2019-02-01 20:58:42,https://github.com/decred/politeia/issues/607#issuecomment-459865488
+2532,4,1,lemonkabir,2019-02-04 17:37:44,https://github.com/decred/politeia/issues/657#issuecomment-460340017
+2533,4,1,s-ben,2019-02-04 18:04:46,https://github.com/decred/politeia/issues/490#issuecomment-460349778
+2534,4,1,camus-code,2019-02-04 19:53:52,https://github.com/decred/politeia/issues/662#issuecomment-460388739
+2535,4,1,chappjc,2019-02-06 22:32:08,https://github.com/decred/politeia/issues/670#issuecomment-461214679
+2536,4,1,lukebp,2019-02-06 23:04:21,https://github.com/decred/politeia/issues/662#issuecomment-461223794
+2537,4,1,sndurkin,2019-02-06 23:05:41,https://github.com/decred/politeia/issues/490#issuecomment-461224144
+2538,4,1,thi4go,2019-02-08 12:44:55,https://github.com/decred/politeia/pull/644#issuecomment-461791585
+2539,4,1,sambiohazard,2019-02-10 20:25:17,https://github.com/decred/politeia/issues/678#issuecomment-462168675
+2540,4,1,linnutee,2019-02-12 11:57:51,https://github.com/decred/politeia/issues/678#issuecomment-462732269
+2541,4,1,lukebp,2019-02-13 15:24:32,https://github.com/decred/politeia/issues/692#issuecomment-463240586
+2542,4,1,camus-code,2019-02-13 18:45:14,https://github.com/decred/politeia/issues/575#issuecomment-463317904
+2543,4,1,camus-code,2019-02-18 21:29:47,https://github.com/decred/politeia/issues/698#issuecomment-464886430
+2544,4,1,s-ben,2019-02-22 19:55:26,https://github.com/decred/politeia/pull/677#issuecomment-466526169
+2545,4,1,s-ben,2019-02-25 02:04:51,https://github.com/decred/politeia/pull/677#issuecomment-466846601
+2546,4,1,lukebp,2019-02-25 16:03:16,https://github.com/decred/politeia/issues/695#issuecomment-467068597
+2547,4,1,lukebp,2019-02-25 16:04:54,https://github.com/decred/politeia/issues/614#issuecomment-467069226
+2548,4,1,lukebp,2019-02-25 16:09:46,https://github.com/decred/politeia/pull/699#issuecomment-467071087
+2549,4,1,lukebp,2019-02-26 12:40:08,https://github.com/decred/politeia/pull/705#issuecomment-467422893
+2550,4,1,thi4go,2019-02-26 13:53:58,https://github.com/decred/politeia/issues/704#issuecomment-467446371
+2551,4,1,thi4go,2019-02-27 15:33:54,https://github.com/decred/politeia/issues/695#issuecomment-467908636
+2552,4,1,linnutee,2019-02-28 19:14:45,https://github.com/decred/politeia/issues/678#issuecomment-468399999
+2553,4,1,alexlyp,2019-02-28 22:47:31,https://github.com/decred/politeia/pull/705#issuecomment-468470175
+2554,4,1,jzbz,2019-03-01 02:44:59,https://github.com/decred/politeia/issues/567#issuecomment-468521218
+2555,4,1,davecgh,2019-03-03 23:35:51,https://github.com/decred/politeia/issues/567#issuecomment-469077353
+2556,4,1,davecgh,2019-03-04 10:22:57,https://github.com/decred/politeia/issues/567#issuecomment-469199486
+2557,4,1,lukebp,2019-03-04 15:09:20,https://github.com/decred/politeia/issues/678#issuecomment-469286734
+2558,4,1,sambiohazard,2019-03-04 22:09:03,https://github.com/decred/politeia/issues/678#issuecomment-469441675
+2559,4,1,xaur,2019-03-05 09:45:40,https://github.com/decred/politeia/issues/678#issuecomment-469612508
+2560,4,1,xaur,2019-03-05 09:48:17,https://github.com/decred/politeia/issues/678#issuecomment-469613422
+2561,4,1,linnutee,2019-03-05 13:13:37,https://github.com/decred/politeia/issues/678#issuecomment-469674706
+2562,4,1,s-ben,2019-03-08 08:57:35,https://github.com/decred/politeia/issues/712#issuecomment-470854619
+2563,4,1,xaur,2019-03-09 10:22:37,https://github.com/decred/politeia/issues/678#issuecomment-471164816
+2564,4,1,lukebp,2019-03-09 17:29:11,https://github.com/decred/politeia/issues/712#issuecomment-471203510
+2565,4,1,lukebp,2019-03-11 13:27:27,https://github.com/decred/politeia/pull/709#issuecomment-471537620
+2566,4,1,thi4go,2019-03-11 14:21:07,https://github.com/decred/politeia/issues/670#issuecomment-471558148
+2567,4,1,xaur,2019-03-11 21:56:59,https://github.com/decred/politeia/issues/720#issuecomment-471751912
+2568,4,1,xaur,2019-03-11 22:11:09,https://github.com/decred/politeia/issues/718#issuecomment-471759186
+2569,4,1,s-ben,2019-03-11 22:25:07,https://github.com/decred/politeia/issues/718#issuecomment-471764024
+2570,4,1,xaur,2019-03-12 09:23:48,https://github.com/decred/politeia/issues/718#issuecomment-471920303
+2571,4,1,s-ben,2019-03-13 03:16:45,https://github.com/decred/politeia/issues/718#issuecomment-472263457
+2572,4,1,xaur,2019-03-13 09:16:01,https://github.com/decred/politeia/issues/718#issuecomment-472340457
+2573,4,1,lukebp,2019-03-13 13:49:04,https://github.com/decred/politeia/issues/717#issuecomment-472429115
+2574,4,1,xaur,2019-03-13 14:56:41,https://github.com/decred/politeia/issues/717#issuecomment-472457651
+2575,4,1,s-ben,2019-03-14 21:07:49,https://github.com/decred/politeia/issues/718#issuecomment-473063270
+2576,4,1,orthomind,2019-03-15 00:08:17,https://github.com/decred/politeia/pull/725#issuecomment-473111440
+2577,4,1,s-ben,2019-03-15 20:32:52,https://github.com/decred/politeia/pull/725#issuecomment-473431694
+2578,4,1,xaur,2019-03-16 15:21:23,https://github.com/decred/politeia/issues/729#issuecomment-473544001
+2579,4,1,lukebp,2019-03-17 20:49:47,https://github.com/decred/politeia/pull/700#issuecomment-473713374
+2580,4,1,thi4go,2019-03-18 02:45:37,https://github.com/decred/politeia/pull/709#issuecomment-473749986
+2581,4,1,RichardRed0x,2019-03-19 11:13:37,https://github.com/decred/politeia/issues/729#issuecomment-474313450
+2582,4,1,RichardRed0x,2019-03-20 03:09:49,https://github.com/decred/politeia/issues/729#issuecomment-474667056
+2583,4,1,xaur,2019-03-20 08:29:21,https://github.com/decred/politeia/issues/729#issuecomment-474733802
+2584,4,1,xaur,2019-03-20 12:45:17,https://github.com/decred/politeia/issues/695#issuecomment-474813157
+2585,4,1,RichardRed0x,2019-03-20 14:17:07,https://github.com/decred/politeia/issues/729#issuecomment-474849308
+2586,4,1,RichardRed0x,2019-03-20 14:18:48,https://github.com/decred/politeia/issues/729#issuecomment-474850202
+2587,4,1,dajohi,2019-03-20 17:59:05,https://github.com/decred/politeia/issues/737#issuecomment-474959699
+2588,4,1,RichardRed0x,2019-03-21 10:44:20,https://github.com/decred/politeia/issues/695#issuecomment-475182706
+2589,4,1,xaur,2019-03-21 14:41:48,https://github.com/decred/politeia/issues/591#issuecomment-475257308
+2590,4,1,dajohi,2019-03-21 14:45:28,https://github.com/decred/politeia/issues/723#issuecomment-475258796
+2591,4,1,thi4go,2019-03-21 14:48:29,https://github.com/decred/politeia/issues/723#issuecomment-475260031
+2592,4,1,lukebp,2019-03-21 16:35:10,https://github.com/decred/politeia/issues/739#issuecomment-475305999
+2593,4,1,s-ben,2019-03-22 00:35:25,https://github.com/decred/politeia/pull/743#issuecomment-475453255
+2594,4,1,s-ben,2019-03-23 07:40:53,https://github.com/decred/politeia/issues/729#issuecomment-475848208
+2595,4,1,xaur,2019-03-23 11:32:26,https://github.com/decred/politeia/issues/729#issuecomment-475862195
+2596,4,1,dajohi,2019-03-25 18:29:37,https://github.com/decred/politeia/issues/751#issuecomment-476323406
+2597,4,1,s-ben,2019-03-27 05:46:29,https://github.com/decred/politeia/pull/744#issuecomment-476986550
+2598,4,1,marcopeereboom,2019-03-27 18:10:23,https://github.com/decred/politeia/pull/755#issuecomment-477286612
+2599,4,1,jrick,2019-03-28 21:14:44,https://github.com/decred/politeia/issues/720#issuecomment-477773598
+2600,4,1,jrick,2019-03-28 21:27:43,https://github.com/decred/politeia/issues/720#issuecomment-477777690
+2601,4,1,marcopeereboom,2019-03-29 17:00:59,https://github.com/decred/politeia/pull/756#issuecomment-478074204
+2602,5,1,marcopeereboom,2017-08-25 15:57:07,https://github.com/decred/politeia/pull/1#discussion_r135293768
+2603,5,1,sndurkin,2017-08-25 23:41:00,https://github.com/decred/politeia/pull/1#discussion_r135372173
+2604,5,1,marcopeereboom,2017-09-07 14:29:37,https://github.com/decred/politeia/pull/7#discussion_r137555133
+2605,5,1,marcopeereboom,2017-09-07 14:30:44,https://github.com/decred/politeia/pull/7#discussion_r137555469
+2606,5,1,marcopeereboom,2017-09-07 14:31:40,https://github.com/decred/politeia/pull/7#discussion_r137555748
+2607,5,1,marcopeereboom,2017-09-07 14:31:50,https://github.com/decred/politeia/pull/7#discussion_r137555789
+2608,5,1,marcopeereboom,2017-09-07 14:33:35,https://github.com/decred/politeia/pull/7#discussion_r137556330
+2609,5,1,marcopeereboom,2017-09-07 15:42:46,https://github.com/decred/politeia/pull/7#discussion_r137577001
+2610,5,1,marcopeereboom,2017-09-07 15:43:02,https://github.com/decred/politeia/pull/7#discussion_r137577080
+2611,5,1,marcopeereboom,2017-09-07 15:50:15,https://github.com/decred/politeia/pull/7#discussion_r137579134
+2612,5,1,marcopeereboom,2017-09-08 11:51:59,https://github.com/decred/politeia/pull/7#discussion_r137771658
+2613,5,1,marcopeereboom,2017-09-08 11:52:08,https://github.com/decred/politeia/pull/7#discussion_r137771686
+2614,5,1,marcopeereboom,2017-09-08 11:52:17,https://github.com/decred/politeia/pull/7#discussion_r137771707
+2615,5,1,marcopeereboom,2017-09-08 11:53:43,https://github.com/decred/politeia/pull/7#discussion_r137772018
+2616,5,1,marcopeereboom,2017-09-12 17:59:27,https://github.com/decred/politeia/pull/9#discussion_r138423064
+2617,5,1,marcopeereboom,2017-09-12 17:59:37,https://github.com/decred/politeia/pull/9#discussion_r138423111
+2618,5,1,marcopeereboom,2017-09-12 18:00:35,https://github.com/decred/politeia/pull/9#discussion_r138423359
+2619,5,1,marcopeereboom,2017-09-12 19:46:46,https://github.com/decred/politeia/pull/9#discussion_r138447390
+2620,5,1,marcopeereboom,2017-09-12 19:48:06,https://github.com/decred/politeia/pull/9#discussion_r138447693
+2621,5,1,marcopeereboom,2017-09-12 19:50:18,https://github.com/decred/politeia/pull/9#discussion_r138448142
+2622,5,1,marcopeereboom,2017-09-18 13:15:18,https://github.com/decred/politeia/pull/24#discussion_r139417869
+2623,5,1,marcopeereboom,2017-09-18 14:27:29,https://github.com/decred/politeia/pull/24#discussion_r139438247
+2624,5,1,marcopeereboom,2017-09-18 14:28:02,https://github.com/decred/politeia/pull/24#discussion_r139438410
+2625,5,1,marcopeereboom,2017-09-18 14:28:14,https://github.com/decred/politeia/pull/24#discussion_r139438470
+2626,5,1,marcopeereboom,2017-09-18 14:28:30,https://github.com/decred/politeia/pull/24#discussion_r139438563
+2627,5,1,marcopeereboom,2017-09-18 14:28:36,https://github.com/decred/politeia/pull/24#discussion_r139438589
+2628,5,1,marcopeereboom,2017-09-18 14:29:55,https://github.com/decred/politeia/pull/24#discussion_r139438990
+2629,5,1,marcopeereboom,2017-09-18 14:31:18,https://github.com/decred/politeia/pull/24#discussion_r139439390
+2630,5,1,marcopeereboom,2017-09-18 14:32:13,https://github.com/decred/politeia/pull/24#discussion_r139439649
+2631,5,1,sndurkin,2017-09-18 14:35:58,https://github.com/decred/politeia/pull/24#discussion_r139440673
+2632,5,1,marcopeereboom,2017-09-21 14:57:43,https://github.com/decred/politeia/pull/34#discussion_r140267193
+2633,5,1,marcopeereboom,2017-09-21 14:58:32,https://github.com/decred/politeia/pull/34#discussion_r140267453
+2634,5,1,marcopeereboom,2017-09-21 14:59:09,https://github.com/decred/politeia/pull/34#discussion_r140267613
+2635,5,1,marcopeereboom,2017-09-21 14:59:42,https://github.com/decred/politeia/pull/34#discussion_r140267778
+2636,5,1,marcopeereboom,2017-09-21 15:01:18,https://github.com/decred/politeia/pull/33#discussion_r140268240
+2637,5,1,marcopeereboom,2017-09-21 15:02:24,https://github.com/decred/politeia/pull/33#discussion_r140268537
+2638,5,1,marcopeereboom,2017-09-21 15:06:06,https://github.com/decred/politeia/pull/33#discussion_r140269538
+2639,5,1,marcopeereboom,2017-09-21 15:06:58,https://github.com/decred/politeia/pull/33#discussion_r140269767
+2640,5,1,marcopeereboom,2017-09-21 15:08:13,https://github.com/decred/politeia/pull/33#discussion_r140270182
+2641,5,1,sndurkin,2017-09-22 18:17:49,https://github.com/decred/politeia/pull/33#discussion_r140562537
+2642,5,1,sndurkin,2017-09-22 18:24:29,https://github.com/decred/politeia/pull/33#discussion_r140564068
+2643,5,1,sndurkin,2017-09-23 03:15:54,https://github.com/decred/politeia/pull/33#discussion_r140624640
+2644,5,1,sndurkin,2017-09-23 03:39:44,https://github.com/decred/politeia/pull/33#discussion_r140624930
+2645,5,1,marcopeereboom,2017-09-27 13:06:48,https://github.com/decred/politeia/pull/33#discussion_r141335936
+2646,5,1,sndurkin,2017-10-01 03:01:46,https://github.com/decred/politeia/pull/45#discussion_r142019505
+2647,5,1,marcopeereboom,2017-10-02 14:58:31,https://github.com/decred/politeia/pull/45#discussion_r142163198
+2648,5,1,marcopeereboom,2017-10-02 14:59:09,https://github.com/decred/politeia/pull/45#discussion_r142163366
+2649,5,1,marcopeereboom,2017-10-02 15:00:12,https://github.com/decred/politeia/pull/45#discussion_r142163713
+2650,5,1,marcopeereboom,2017-10-02 15:00:34,https://github.com/decred/politeia/pull/45#discussion_r142163832
+2651,5,1,marcopeereboom,2017-10-02 15:44:51,https://github.com/decred/politeia/pull/45#discussion_r142176896
+2652,5,1,marcopeereboom,2017-10-02 15:58:09,https://github.com/decred/politeia/pull/45#discussion_r142180707
+2653,5,1,marcopeereboom,2017-10-02 16:38:14,https://github.com/decred/politeia/pull/45#discussion_r142190680
+2654,5,1,marcopeereboom,2017-10-04 14:54:18,https://github.com/decred/politeia/pull/47#discussion_r142694611
+2655,5,1,marcopeereboom,2017-10-04 14:56:13,https://github.com/decred/politeia/pull/47#discussion_r142695255
+2656,5,1,marcopeereboom,2017-10-04 14:57:42,https://github.com/decred/politeia/pull/47#discussion_r142695759
+2657,5,1,marcopeereboom,2017-10-04 14:58:38,https://github.com/decred/politeia/pull/47#discussion_r142696068
+2658,5,1,marcopeereboom,2017-10-04 14:59:11,https://github.com/decred/politeia/pull/47#discussion_r142696245
+2659,5,1,marcopeereboom,2017-10-05 12:38:39,https://github.com/decred/politeia/pull/47#discussion_r142924957
+2660,5,1,marcopeereboom,2017-10-05 12:39:01,https://github.com/decred/politeia/pull/47#discussion_r142925022
+2661,5,1,marcopeereboom,2017-10-05 12:41:24,https://github.com/decred/politeia/pull/47#discussion_r142925566
+2662,5,1,go1dfish,2017-10-11 18:14:20,https://github.com/decred/politeia/pull/53#discussion_r144093035
+2663,5,1,go1dfish,2017-10-11 18:49:25,https://github.com/decred/politeia/pull/53#discussion_r144102733
+2664,5,1,marcopeereboom,2017-10-16 10:09:38,https://github.com/decred/politeia/pull/53#discussion_r144805724
+2665,5,1,marcopeereboom,2017-10-16 14:30:21,https://github.com/decred/politeia/pull/54#discussion_r144863339
+2666,5,1,sndurkin,2017-10-17 15:27:30,https://github.com/decred/politeia/pull/60#discussion_r145166543
+2667,5,1,marcopeereboom,2017-10-31 14:22:15,https://github.com/decred/politeia/pull/104#discussion_r148010302
+2668,5,1,sndurkin,2017-10-31 14:37:50,https://github.com/decred/politeia/pull/104#discussion_r148015213
+2669,5,1,sndurkin,2017-11-03 13:18:29,https://github.com/decred/politeia/pull/106#discussion_r148778600
+2670,5,1,sndurkin,2017-11-03 13:20:11,https://github.com/decred/politeia/pull/106#discussion_r148778964
+2671,5,1,go1dfish,2017-11-05 21:09:45,https://github.com/decred/politeia/pull/106#discussion_r148970813
+2672,5,1,go1dfish,2017-11-05 21:10:57,https://github.com/decred/politeia/pull/106#discussion_r148970879
+2673,5,1,sndurkin,2017-11-06 01:19:39,https://github.com/decred/politeia/pull/106#discussion_r148979282
+2674,5,1,sndurkin,2017-11-06 01:20:35,https://github.com/decred/politeia/pull/106#discussion_r148979326
+2675,5,1,sndurkin,2017-11-06 01:34:12,https://github.com/decred/politeia/pull/106#discussion_r148979999
+2676,5,1,sndurkin,2017-11-06 01:41:43,https://github.com/decred/politeia/pull/106#discussion_r148980355
+2677,5,1,marcopeereboom,2017-11-06 14:28:12,https://github.com/decred/politeia/pull/106#discussion_r149092005
+2678,5,1,marcopeereboom,2017-11-06 14:35:36,https://github.com/decred/politeia/pull/106#discussion_r149094030
+2679,5,1,marcopeereboom,2017-11-06 14:43:38,https://github.com/decred/politeia/pull/106#discussion_r149096116
+2680,5,1,marcopeereboom,2017-11-06 14:46:24,https://github.com/decred/politeia/pull/106#discussion_r149096888
+2681,5,1,marcopeereboom,2017-11-06 14:47:20,https://github.com/decred/politeia/pull/106#discussion_r149097144
+2682,5,1,sndurkin,2017-11-06 14:53:35,https://github.com/decred/politeia/pull/106#discussion_r149098985
+2683,5,1,go1dfish,2017-11-06 17:33:12,https://github.com/decred/politeia/pull/106#discussion_r149148093
+2684,5,1,go1dfish,2017-11-06 17:33:40,https://github.com/decred/politeia/pull/106#discussion_r149148249
+2685,5,1,marcopeereboom,2017-11-07 13:31:57,https://github.com/decred/politeia/pull/116#discussion_r149367169
+2686,5,1,marcopeereboom,2017-11-07 13:32:17,https://github.com/decred/politeia/pull/116#discussion_r149367226
+2687,5,1,marcopeereboom,2017-11-07 13:34:15,https://github.com/decred/politeia/pull/116#discussion_r149367669
+2688,5,1,marcopeereboom,2017-11-07 13:35:30,https://github.com/decred/politeia/pull/116#discussion_r149367947
+2689,5,1,marcopeereboom,2017-11-07 13:36:59,https://github.com/decred/politeia/pull/116#discussion_r149368295
+2690,5,1,marcopeereboom,2017-11-07 13:38:44,https://github.com/decred/politeia/pull/116#discussion_r149368690
+2691,5,1,marcopeereboom,2017-11-07 13:43:56,https://github.com/decred/politeia/pull/116#discussion_r149369985
+2692,5,1,sndurkin,2017-11-08 02:29:30,https://github.com/decred/politeia/pull/116#discussion_r149561289
+2693,5,1,sndurkin,2017-11-08 02:29:39,https://github.com/decred/politeia/pull/116#discussion_r149561303
+2694,5,1,sndurkin,2017-11-08 02:29:54,https://github.com/decred/politeia/pull/116#discussion_r149561331
+2695,5,1,sndurkin,2017-11-08 02:30:24,https://github.com/decred/politeia/pull/116#discussion_r149561375
+2696,5,1,sndurkin,2017-11-08 02:30:50,https://github.com/decred/politeia/pull/116#discussion_r149561429
+2697,5,1,marcopeereboom,2017-11-08 13:56:37,https://github.com/decred/politeia/pull/116#discussion_r149674112
+2698,5,1,marcopeereboom,2017-11-08 13:58:17,https://github.com/decred/politeia/pull/116#discussion_r149674563
+2699,5,1,marcopeereboom,2017-11-07 21:10:23,https://github.com/decred/politeia/pull/126#discussion_r149504251
+2700,5,1,marcopeereboom,2017-11-08 13:43:33,https://github.com/decred/politeia/pull/126#discussion_r149670783
+2701,5,1,marcopeereboom,2017-11-08 13:45:54,https://github.com/decred/politeia/pull/126#discussion_r149671395
+2802,5,1,rgeraldes,2017-11-08 13:56:39,https://github.com/decred/politeia/pull/126#discussion_r149674122
+2803,5,1,marcopeereboom,2017-11-08 14:03:05,https://github.com/decred/politeia/pull/126#discussion_r149675849
+2804,5,1,sndurkin,2017-11-08 15:35:36,https://github.com/decred/politeia/pull/126#discussion_r149704243
+2805,5,1,sndurkin,2017-11-08 15:37:24,https://github.com/decred/politeia/pull/126#discussion_r149704804
+2806,5,1,sndurkin,2017-11-08 15:57:44,https://github.com/decred/politeia/pull/126#discussion_r149711431
+2807,5,1,rgeraldes,2017-11-08 19:11:56,https://github.com/decred/politeia/pull/126#discussion_r149767983
+2808,5,1,rgeraldes,2017-11-08 19:17:56,https://github.com/decred/politeia/pull/126#discussion_r149769564
+2809,5,1,marcopeereboom,2017-11-09 14:49:36,https://github.com/decred/politeia/pull/126#discussion_r149981839
+2810,5,1,marcopeereboom,2017-11-09 14:50:34,https://github.com/decred/politeia/pull/126#discussion_r149982112
+2811,5,1,marcopeereboom,2017-11-09 14:52:28,https://github.com/decred/politeia/pull/126#discussion_r149982673
+2812,5,1,marcopeereboom,2017-11-09 14:54:05,https://github.com/decred/politeia/pull/126#discussion_r149983111
+2813,5,1,rgeraldes,2017-11-09 17:43:02,https://github.com/decred/politeia/pull/126#discussion_r150035192
+2814,5,1,rgeraldes,2017-11-09 17:43:33,https://github.com/decred/politeia/pull/126#discussion_r150035336
+2815,5,1,sndurkin,2017-11-09 17:50:41,https://github.com/decred/politeia/pull/126#discussion_r150037327
+2816,5,1,sndurkin,2017-11-09 17:53:39,https://github.com/decred/politeia/pull/126#discussion_r150038065
+2817,5,1,rgeraldes,2017-11-09 18:04:48,https://github.com/decred/politeia/pull/126#discussion_r150040801
+2818,5,1,sndurkin,2017-11-07 01:42:22,https://github.com/decred/politeia/pull/112#discussion_r149254014
+2819,5,1,rgeraldes,2017-11-07 19:46:55,https://github.com/decred/politeia/pull/112#discussion_r149483448
+2820,5,1,marcopeereboom,2017-11-08 13:53:31,https://github.com/decred/politeia/pull/112#discussion_r149673276
+2821,5,1,marcopeereboom,2017-11-08 13:53:48,https://github.com/decred/politeia/pull/112#discussion_r149673346
+2822,5,1,sndurkin,2017-11-10 04:12:35,https://github.com/decred/politeia/pull/133#discussion_r150150841
+2823,5,1,sndurkin,2017-11-10 04:13:51,https://github.com/decred/politeia/pull/133#discussion_r150150926
+2824,5,1,sndurkin,2017-11-10 04:14:28,https://github.com/decred/politeia/pull/133#discussion_r150150963
+2825,5,1,sndurkin,2017-11-10 04:15:51,https://github.com/decred/politeia/pull/133#discussion_r150151091
+2826,5,1,sndurkin,2017-11-10 04:17:29,https://github.com/decred/politeia/pull/133#discussion_r150151226
+2827,5,1,sndurkin,2017-11-10 04:19:32,https://github.com/decred/politeia/pull/133#discussion_r150151412
+2828,5,1,sndurkin,2017-11-10 04:20:08,https://github.com/decred/politeia/pull/133#discussion_r150151454
+2829,5,1,dajohi,2017-11-08 17:03:38,https://github.com/decred/politeia/pull/127#discussion_r149732428
+2830,5,1,dajohi,2017-11-09 16:16:36,https://github.com/decred/politeia/pull/127#discussion_r150009120
+2831,5,1,marcopeereboom,2017-11-10 16:28:14,https://github.com/decred/politeia/pull/127#discussion_r150278995
+2832,5,1,sndurkin,2017-11-09 17:08:42,https://github.com/decred/politeia/pull/131#discussion_r150026043
+2833,5,1,sndurkin,2017-11-15 15:22:37,https://github.com/decred/politeia/pull/131#discussion_r151157010
+2834,5,1,rgeraldes,2017-11-18 00:20:13,https://github.com/decred/politeia/pull/136#discussion_r151818164
+2835,5,1,rgeraldes,2017-11-18 00:27:40,https://github.com/decred/politeia/pull/136#discussion_r151818910
+2836,5,1,rgeraldes,2017-11-18 00:29:50,https://github.com/decred/politeia/pull/136#discussion_r151819131
+2837,5,1,rgeraldes,2017-11-18 00:31:12,https://github.com/decred/politeia/pull/136#discussion_r151819294
+2838,5,1,sndurkin,2017-11-17 15:10:00,https://github.com/decred/politeia/pull/149#discussion_r151707258
+2839,5,1,vctt94,2017-11-17 15:39:38,https://github.com/decred/politeia/pull/149#discussion_r151714843
+2840,5,1,sndurkin,2017-11-17 17:44:46,https://github.com/decred/politeia/pull/149#discussion_r151746462
+2841,5,1,sndurkin,2017-11-17 17:44:50,https://github.com/decred/politeia/pull/149#discussion_r151746479
+2842,5,1,sndurkin,2017-11-17 17:46:09,https://github.com/decred/politeia/pull/149#discussion_r151746761
+2843,5,1,sndurkin,2017-11-17 17:47:50,https://github.com/decred/politeia/pull/149#discussion_r151747105
+2844,5,1,sndurkin,2017-11-17 17:48:48,https://github.com/decred/politeia/pull/149#discussion_r151747323
+2845,5,1,sndurkin,2017-11-17 17:50:31,https://github.com/decred/politeia/pull/149#discussion_r151747700
+2846,5,1,rgeraldes,2017-11-17 23:56:06,https://github.com/decred/politeia/pull/149#discussion_r151815860
+2847,5,1,rgeraldes,2017-11-18 00:00:32,https://github.com/decred/politeia/pull/149#discussion_r151816358
+2848,5,1,sndurkin,2017-11-18 05:13:41,https://github.com/decred/politeia/pull/149#discussion_r151828978
+2849,5,1,marcopeereboom,2017-11-20 14:16:03,https://github.com/decred/politeia/pull/149#discussion_r152000969
+2850,5,1,marcopeereboom,2017-11-20 14:17:06,https://github.com/decred/politeia/pull/149#discussion_r152001220
+2851,5,1,marcopeereboom,2017-11-20 14:19:13,https://github.com/decred/politeia/pull/149#discussion_r152001729
+2852,5,1,rgeraldes,2017-11-20 14:22:41,https://github.com/decred/politeia/pull/149#discussion_r152002581
+2853,5,1,sndurkin,2017-11-14 04:50:53,https://github.com/decred/politeia/pull/141#discussion_r150737046
+2854,5,1,sndurkin,2017-11-14 05:04:42,https://github.com/decred/politeia/pull/141#discussion_r150738428
+2855,5,1,sudoscript,2017-11-14 05:40:17,https://github.com/decred/politeia/pull/141#discussion_r150741679
+2856,5,1,sndurkin,2017-11-14 14:31:27,https://github.com/decred/politeia/pull/141#discussion_r150848078
+2857,5,1,sndurkin,2017-11-28 04:12:07,https://github.com/decred/politeia/pull/159#discussion_r153391629
+2858,5,1,sndurkin,2017-11-28 04:15:36,https://github.com/decred/politeia/pull/159#discussion_r153391945
+2859,5,1,sndurkin,2017-11-28 04:26:21,https://github.com/decred/politeia/pull/159#discussion_r153393000
+2860,5,1,sndurkin,2017-11-28 04:28:38,https://github.com/decred/politeia/pull/159#discussion_r153393222
+2861,5,1,sndurkin,2017-11-28 04:36:46,https://github.com/decred/politeia/pull/159#discussion_r153393935
+2862,5,1,sndurkin,2017-11-28 05:18:42,https://github.com/decred/politeia/pull/159#discussion_r153397563
+2863,5,1,sndurkin,2017-11-28 05:19:21,https://github.com/decred/politeia/pull/159#discussion_r153397614
+2864,5,1,sndurkin,2017-11-28 05:20:41,https://github.com/decred/politeia/pull/159#discussion_r153397748
+2865,5,1,sndurkin,2017-11-28 05:22:36,https://github.com/decred/politeia/pull/159#discussion_r153397915
+2866,5,1,marcopeereboom,2017-11-29 18:11:09,https://github.com/decred/politeia/pull/159#discussion_r153869890
+2867,5,1,marcopeereboom,2017-11-29 18:11:20,https://github.com/decred/politeia/pull/159#discussion_r153869939
+2868,5,1,marcopeereboom,2017-11-29 18:12:07,https://github.com/decred/politeia/pull/159#discussion_r153870138
+2869,5,1,marcopeereboom,2017-11-29 18:26:17,https://github.com/decred/politeia/pull/159#discussion_r153873931
+2870,5,1,marcopeereboom,2017-11-29 18:26:46,https://github.com/decred/politeia/pull/159#discussion_r153874074
+2871,5,1,marcopeereboom,2017-11-29 18:27:56,https://github.com/decred/politeia/pull/159#discussion_r153874431
+2872,5,1,marcopeereboom,2017-11-29 18:28:15,https://github.com/decred/politeia/pull/159#discussion_r153874529
+2873,5,1,sndurkin,2017-11-30 16:41:09,https://github.com/decred/politeia/pull/165#discussion_r154132124
+2874,5,1,marcopeereboom,2017-11-20 16:26:45,https://github.com/decred/politeia/pull/156#discussion_r152040664
+2875,5,1,sndurkin,2017-11-20 16:37:26,https://github.com/decred/politeia/pull/156#discussion_r152043778
+2876,5,1,marcopeereboom,2017-11-30 13:29:14,https://github.com/decred/politeia/pull/156#discussion_r154073974
+2877,5,1,marcopeereboom,2017-12-07 14:54:26,https://github.com/decred/politeia/pull/181#discussion_r155542644
+2878,5,1,sndurkin,2017-12-06 14:10:24,https://github.com/decred/politeia/pull/152#discussion_r155245553
+2879,5,1,sndurkin,2017-12-06 14:23:52,https://github.com/decred/politeia/pull/152#discussion_r155249160
+2880,5,1,sndurkin,2017-12-06 14:24:38,https://github.com/decred/politeia/pull/152#discussion_r155249362
+2881,5,1,sndurkin,2017-12-06 14:35:24,https://github.com/decred/politeia/pull/152#discussion_r155252347
+2882,5,1,sndurkin,2017-12-06 14:51:42,https://github.com/decred/politeia/pull/152#discussion_r155257139
+2883,5,1,jolan,2017-12-11 18:35:54,https://github.com/decred/politeia/pull/152#discussion_r156159931
+2884,5,1,jolan,2017-12-11 18:35:59,https://github.com/decred/politeia/pull/152#discussion_r156159959
+2885,5,1,jolan,2017-12-11 18:36:07,https://github.com/decred/politeia/pull/152#discussion_r156160016
+2886,5,1,jolan,2017-12-11 18:36:59,https://github.com/decred/politeia/pull/152#discussion_r156160280
+2887,5,1,jolan,2017-12-11 18:37:25,https://github.com/decred/politeia/pull/152#discussion_r156160395
+2888,5,1,sndurkin,2017-12-13 19:56:17,https://github.com/decred/politeia/pull/183#discussion_r156765877
+2889,5,1,sndurkin,2017-12-13 19:57:38,https://github.com/decred/politeia/pull/183#discussion_r156766229
+2890,5,1,sndurkin,2017-12-13 20:04:12,https://github.com/decred/politeia/pull/183#discussion_r156767796
+2891,5,1,sndurkin,2017-12-14 04:51:53,https://github.com/decred/politeia/pull/183#discussion_r156854439
+2892,5,1,sndurkin,2017-12-14 04:57:22,https://github.com/decred/politeia/pull/183#discussion_r156854901
+2893,5,1,sndurkin,2017-12-14 05:38:39,https://github.com/decred/politeia/pull/183#discussion_r156858426
+2894,5,1,sndurkin,2017-12-14 05:39:33,https://github.com/decred/politeia/pull/183#discussion_r156858491
+2895,5,1,sndurkin,2017-12-14 05:44:33,https://github.com/decred/politeia/pull/183#discussion_r156858932
+2896,5,1,marcopeereboom,2017-12-14 13:23:54,https://github.com/decred/politeia/pull/183#discussion_r156941598
+2897,5,1,marcopeereboom,2017-12-14 13:24:05,https://github.com/decred/politeia/pull/183#discussion_r156941638
+2898,5,1,marcopeereboom,2017-12-14 13:26:06,https://github.com/decred/politeia/pull/183#discussion_r156942087
+2899,5,1,marcopeereboom,2017-12-14 16:45:29,https://github.com/decred/politeia/pull/183#discussion_r156998273
+2900,5,1,marcopeereboom,2017-12-14 16:46:30,https://github.com/decred/politeia/pull/183#discussion_r156998600
+2901,5,1,marcopeereboom,2017-12-14 16:47:30,https://github.com/decred/politeia/pull/183#discussion_r156998899
+2902,5,1,marcopeereboom,2017-12-14 16:51:21,https://github.com/decred/politeia/pull/183#discussion_r157000001
+2903,5,1,marcopeereboom,2017-12-14 16:52:19,https://github.com/decred/politeia/pull/183#discussion_r157000283
+2904,5,1,marcopeereboom,2017-12-14 16:53:05,https://github.com/decred/politeia/pull/183#discussion_r157000491
+2905,5,1,vctt94,2017-12-14 17:51:02,https://github.com/decred/politeia/pull/183#discussion_r157015943
+2906,5,1,marcopeereboom,2017-12-15 17:43:59,https://github.com/decred/politeia/pull/183#discussion_r157259234
+2907,5,1,marcopeereboom,2017-12-04 13:52:13,https://github.com/decred/politeia/pull/151#discussion_r154652774
+2908,5,1,marcopeereboom,2017-12-04 13:52:47,https://github.com/decred/politeia/pull/151#discussion_r154652903
+2909,5,1,marcopeereboom,2017-12-04 13:58:35,https://github.com/decred/politeia/pull/151#discussion_r154654376
+2910,5,1,rgeraldes,2017-12-04 14:09:21,https://github.com/decred/politeia/pull/151#discussion_r154657023
+2911,5,1,rgeraldes,2017-12-04 14:09:42,https://github.com/decred/politeia/pull/151#discussion_r154657101
+2912,5,1,marcopeereboom,2018-01-15 17:16:44,https://github.com/decred/politeia/pull/200#discussion_r161576651
+2913,5,1,marcopeereboom,2018-01-15 17:20:34,https://github.com/decred/politeia/pull/200#discussion_r161577752
+2914,5,1,sndurkin,2018-01-15 17:33:05,https://github.com/decred/politeia/pull/200#discussion_r161580103
+2915,5,1,sndurkin,2018-01-15 17:36:36,https://github.com/decred/politeia/pull/200#discussion_r161580794
+2916,5,1,marcopeereboom,2018-01-15 17:41:32,https://github.com/decred/politeia/pull/200#discussion_r161581737
+2917,5,1,sndurkin,2018-01-15 19:15:37,https://github.com/decred/politeia/pull/200#discussion_r161597498
+2918,5,1,sndurkin,2018-01-18 16:43:57,https://github.com/decred/politeia/pull/214#discussion_r162401150
+2919,5,1,sndurkin,2018-01-18 16:44:10,https://github.com/decred/politeia/pull/214#discussion_r162401229
+2920,5,1,sndurkin,2018-01-18 16:44:49,https://github.com/decred/politeia/pull/214#discussion_r162401422
+2921,5,1,sndurkin,2018-01-18 16:45:46,https://github.com/decred/politeia/pull/214#discussion_r162401708
+2922,5,1,sndurkin,2018-01-18 16:46:27,https://github.com/decred/politeia/pull/214#discussion_r162401952
+2923,5,1,sndurkin,2018-01-18 16:47:08,https://github.com/decred/politeia/pull/214#discussion_r162402164
+2924,5,1,sndurkin,2018-01-18 16:49:40,https://github.com/decred/politeia/pull/214#discussion_r162403061
+2925,5,1,sndurkin,2018-01-18 16:50:50,https://github.com/decred/politeia/pull/214#discussion_r162403422
+2926,5,1,sndurkin,2018-01-18 16:52:13,https://github.com/decred/politeia/pull/214#discussion_r162403849
+2927,5,1,sndurkin,2018-01-18 16:52:37,https://github.com/decred/politeia/pull/214#discussion_r162403976
+2928,5,1,sndurkin,2018-01-18 16:53:11,https://github.com/decred/politeia/pull/214#discussion_r162404130
+2929,5,1,sndurkin,2018-01-18 16:56:41,https://github.com/decred/politeia/pull/214#discussion_r162405248
+2930,5,1,sndurkin,2018-01-20 02:09:12,https://github.com/decred/politeia/pull/214#discussion_r162769918
+2931,5,1,sndurkin,2018-01-20 02:10:07,https://github.com/decred/politeia/pull/214#discussion_r162769962
+2932,5,1,sndurkin,2018-01-20 02:10:44,https://github.com/decred/politeia/pull/214#discussion_r162769989
+2933,5,1,sndurkin,2018-01-20 02:15:13,https://github.com/decred/politeia/pull/214#discussion_r162770206
+2934,5,1,sndurkin,2018-01-20 02:16:19,https://github.com/decred/politeia/pull/214#discussion_r162770257
+2935,5,1,sndurkin,2018-01-22 02:09:20,https://github.com/decred/politeia/pull/214#discussion_r162837296
+2936,5,1,sndurkin,2018-01-22 02:09:29,https://github.com/decred/politeia/pull/214#discussion_r162837308
+2937,5,1,fernandoabolafio,2018-01-22 12:52:43,https://github.com/decred/politeia/pull/214#discussion_r162927667
+2938,5,1,fernandoabolafio,2018-01-22 12:52:48,https://github.com/decred/politeia/pull/214#discussion_r162927678
+2939,5,1,marcopeereboom,2018-01-22 15:18:27,https://github.com/decred/politeia/pull/216#discussion_r162966728
+2940,5,1,sndurkin,2018-01-09 15:29:55,https://github.com/decred/politeia/pull/198#discussion_r160437746
+2941,5,1,sndurkin,2018-02-03 14:28:37,https://github.com/decred/politeia/pull/198#discussion_r165815998
+2942,5,1,sndurkin,2018-02-03 14:32:19,https://github.com/decred/politeia/pull/198#discussion_r165816111
+2943,5,1,sndurkin,2018-02-06 03:06:56,https://github.com/decred/politeia/pull/198#discussion_r166176617
+2944,5,1,sndurkin,2018-02-01 04:41:51,https://github.com/decred/politeia/pull/222#discussion_r165258715
+2945,5,1,sndurkin,2018-02-01 04:42:22,https://github.com/decred/politeia/pull/222#discussion_r165258748
+2946,5,1,sndurkin,2018-02-01 04:52:26,https://github.com/decred/politeia/pull/222#discussion_r165259543
+2947,5,1,sndurkin,2018-02-01 04:59:58,https://github.com/decred/politeia/pull/222#discussion_r165260257
+2948,5,1,AlanL1,2018-02-01 16:14:37,https://github.com/decred/politeia/pull/222#discussion_r165405693
+2949,5,1,sndurkin,2018-02-01 20:54:53,https://github.com/decred/politeia/pull/222#discussion_r165484587
+2950,5,1,AlanL1,2018-02-02 17:08:19,https://github.com/decred/politeia/pull/222#discussion_r165702296
+2951,5,1,marcopeereboom,2018-02-06 15:32:50,https://github.com/decred/politeia/pull/222#discussion_r166340296
+2952,5,1,AlanL1,2018-02-06 17:16:57,https://github.com/decred/politeia/pull/222#discussion_r166377014
+2953,5,1,sndurkin,2018-02-01 04:33:07,https://github.com/decred/politeia/pull/221#discussion_r165257951
+2954,5,1,sndurkin,2018-02-01 04:33:35,https://github.com/decred/politeia/pull/221#discussion_r165257992
+2955,5,1,AlanL1,2018-02-01 16:02:57,https://github.com/decred/politeia/pull/221#discussion_r165401758
+2956,5,1,AlanL1,2018-02-06 10:49:22,https://github.com/decred/politeia/pull/221#discussion_r166255222
+2957,5,1,sndurkin,2018-02-06 13:48:45,https://github.com/decred/politeia/pull/221#discussion_r166303864
+2958,5,1,AlanL1,2018-02-06 14:41:01,https://github.com/decred/politeia/pull/221#discussion_r166323087
+2959,5,1,AlanL1,2018-02-06 17:24:12,https://github.com/decred/politeia/pull/221#discussion_r166379287
+2960,5,1,sndurkin,2018-02-06 17:26:20,https://github.com/decred/politeia/pull/221#discussion_r166379951
+2961,5,1,AlanL1,2018-02-06 17:28:53,https://github.com/decred/politeia/pull/221#discussion_r166380755
+2962,5,1,sndurkin,2018-02-13 01:49:29,https://github.com/decred/politeia/pull/221#discussion_r167741482
+2963,5,1,AlanL1,2018-02-13 02:24:28,https://github.com/decred/politeia/pull/221#discussion_r167745780
+2964,5,1,sndurkin,2018-02-13 02:35:35,https://github.com/decred/politeia/pull/221#discussion_r167747173
+2965,5,1,AlanL1,2018-02-13 03:09:23,https://github.com/decred/politeia/pull/221#discussion_r167750824
+2966,5,1,sndurkin,2018-02-13 03:18:12,https://github.com/decred/politeia/pull/221#discussion_r167751744
+2967,5,1,marcopeereboom,2018-02-23 15:30:24,https://github.com/decred/politeia/pull/232#discussion_r170281305
+2968,5,1,sndurkin,2018-02-23 19:34:27,https://github.com/decred/politeia/pull/232#discussion_r170346467
+2969,5,1,marcopeereboom,2018-03-07 14:43:27,https://github.com/decred/politeia/pull/232#discussion_r172863239
+2970,5,1,marcopeereboom,2018-03-07 14:49:40,https://github.com/decred/politeia/pull/232#discussion_r172865567
+2971,5,1,marcopeereboom,2018-03-07 14:50:14,https://github.com/decred/politeia/pull/232#discussion_r172865752
+2972,5,1,marcopeereboom,2018-03-07 14:50:39,https://github.com/decred/politeia/pull/232#discussion_r172865891
+2973,5,1,marcopeereboom,2018-03-07 14:51:15,https://github.com/decred/politeia/pull/232#discussion_r172866066
+2974,5,1,marcopeereboom,2018-03-07 14:51:46,https://github.com/decred/politeia/pull/232#discussion_r172866254
+2975,5,1,marcopeereboom,2018-03-07 14:52:04,https://github.com/decred/politeia/pull/232#discussion_r172866371
+2976,5,1,marcopeereboom,2018-03-07 14:52:53,https://github.com/decred/politeia/pull/232#discussion_r172866637
+2977,5,1,marcopeereboom,2018-03-07 14:53:14,https://github.com/decred/politeia/pull/232#discussion_r172866760
+2978,5,1,sudoscript,2018-03-03 23:54:51,https://github.com/decred/politeia/pull/234#discussion_r172032477
+2979,5,1,marcopeereboom,2018-03-20 17:17:43,https://github.com/decred/politeia/pull/234#discussion_r175852566
+2980,5,1,sndurkin,2018-01-20 15:51:29,https://github.com/decred/politeia/pull/212#discussion_r162785809
+2981,5,1,sndurkin,2018-01-20 15:55:06,https://github.com/decred/politeia/pull/212#discussion_r162785894
+2982,5,1,sndurkin,2018-01-20 15:55:59,https://github.com/decred/politeia/pull/212#discussion_r162785920
+2983,5,1,sndurkin,2018-01-20 16:03:17,https://github.com/decred/politeia/pull/212#discussion_r162786069
+2984,5,1,marcopeereboom,2018-04-04 13:01:43,https://github.com/decred/politeia/pull/212#discussion_r179130598
+2985,5,1,vctt94,2018-03-29 20:54:44,https://github.com/decred/politeia/pull/241#discussion_r178178903
+2986,5,1,marcopeereboom,2018-04-03 16:38:32,https://github.com/decred/politeia/pull/241#discussion_r178887318
+2987,5,1,vctt94,2018-04-03 20:34:21,https://github.com/decred/politeia/pull/241#discussion_r178953455
+2988,5,1,dajohi,2018-04-17 16:13:21,https://github.com/decred/politeia/pull/254#discussion_r182138153
+2989,5,1,marcopeereboom,2018-04-17 16:16:06,https://github.com/decred/politeia/pull/254#discussion_r182139084
+2990,5,1,sndurkin,2018-04-24 14:20:21,https://github.com/decred/politeia/pull/256#discussion_r183748692
+2991,5,1,vctt94,2018-04-24 18:33:21,https://github.com/decred/politeia/pull/256#discussion_r183837161
+2992,5,1,sndurkin,2018-02-23 04:36:03,https://github.com/decred/politeia/pull/229#discussion_r170165039
+2993,5,1,sndurkin,2018-02-23 04:37:26,https://github.com/decred/politeia/pull/229#discussion_r170165266
+2994,5,1,sndurkin,2018-02-23 04:40:26,https://github.com/decred/politeia/pull/229#discussion_r170165547
+2995,5,1,sndurkin,2018-02-23 04:43:28,https://github.com/decred/politeia/pull/229#discussion_r170165799
+2996,5,1,vctt94,2018-03-13 11:59:26,https://github.com/decred/politeia/pull/229#discussion_r174103158
+2997,5,1,vctt94,2018-03-13 11:59:34,https://github.com/decred/politeia/pull/229#discussion_r174103196
+2998,5,1,vctt94,2018-03-13 11:59:41,https://github.com/decred/politeia/pull/229#discussion_r174103217
+2999,5,1,vctt94,2018-03-13 11:59:46,https://github.com/decred/politeia/pull/229#discussion_r174103234
+3000,5,1,marcopeereboom,2018-04-30 19:39:30,https://github.com/decred/politeia/pull/229#discussion_r185087653
+3001,5,1,marcopeereboom,2018-04-30 19:40:25,https://github.com/decred/politeia/pull/229#discussion_r185087909
+3002,5,1,marcopeereboom,2018-04-30 19:41:26,https://github.com/decred/politeia/pull/229#discussion_r185088215
+3003,5,1,marcopeereboom,2018-04-30 19:42:03,https://github.com/decred/politeia/pull/229#discussion_r185088340
+3004,5,1,marcopeereboom,2018-05-01 15:23:19,https://github.com/decred/politeia/pull/229#discussion_r185247758
+3005,5,1,marcopeereboom,2018-05-01 15:23:35,https://github.com/decred/politeia/pull/229#discussion_r185247826
+3006,5,1,marcopeereboom,2018-05-01 15:24:21,https://github.com/decred/politeia/pull/229#discussion_r185248025
+3007,5,1,marcopeereboom,2018-05-01 15:24:42,https://github.com/decred/politeia/pull/229#discussion_r185248108
+3008,5,1,marcopeereboom,2018-05-01 15:25:35,https://github.com/decred/politeia/pull/229#discussion_r185248363
+3009,5,1,marcopeereboom,2018-05-01 15:26:12,https://github.com/decred/politeia/pull/229#discussion_r185248542
+3010,5,1,marcopeereboom,2018-05-01 15:27:51,https://github.com/decred/politeia/pull/229#discussion_r185248982
+3011,5,1,sndurkin,2018-05-01 15:30:55,https://github.com/decred/politeia/pull/229#discussion_r185249771
+3012,5,1,sndurkin,2018-05-01 15:37:24,https://github.com/decred/politeia/pull/229#discussion_r185251473
+3013,5,1,sndurkin,2018-05-01 15:41:51,https://github.com/decred/politeia/pull/229#discussion_r185252746
+3014,5,1,vctt94,2018-05-01 18:49:58,https://github.com/decred/politeia/pull/229#discussion_r185301630
+3015,5,1,vctt94,2018-05-01 18:50:17,https://github.com/decred/politeia/pull/229#discussion_r185301725
+3016,5,1,marcopeereboom,2018-05-09 20:14:26,https://github.com/decred/politeia/pull/274#discussion_r187162603
+3017,5,1,sndurkin,2018-05-10 14:21:10,https://github.com/decred/politeia/pull/275#discussion_r187344456
+3018,5,1,fernandoabolafio,2018-05-10 14:31:10,https://github.com/decred/politeia/pull/275#discussion_r187347534
+3019,5,1,marcopeereboom,2018-05-23 14:59:22,https://github.com/decred/politeia/pull/290#discussion_r190281801
+3020,5,1,fernandoabolafio,2018-05-24 23:43:50,https://github.com/decred/politeia/pull/297#discussion_r190759781
+3021,5,1,sndurkin,2018-05-25 19:26:09,https://github.com/decred/politeia/pull/297#discussion_r190989493
+3022,5,1,sndurkin,2018-05-25 19:26:55,https://github.com/decred/politeia/pull/297#discussion_r190989667
+3023,5,1,sndurkin,2018-05-25 19:27:39,https://github.com/decred/politeia/pull/297#discussion_r190989833
+3024,5,1,sndurkin,2018-05-28 15:16:43,https://github.com/decred/politeia/pull/297#discussion_r191230721
+3025,5,1,sndurkin,2018-05-28 15:17:43,https://github.com/decred/politeia/pull/297#discussion_r191230905
+3026,5,1,sndurkin,2018-05-28 15:19:51,https://github.com/decred/politeia/pull/297#discussion_r191231374
+3027,5,1,marcopeereboom,2018-05-29 10:32:09,https://github.com/decred/politeia/pull/297#discussion_r191376226
+3028,5,1,marcopeereboom,2018-05-29 10:32:35,https://github.com/decred/politeia/pull/297#discussion_r191376335
+3029,5,1,marcopeereboom,2018-05-29 10:35:59,https://github.com/decred/politeia/pull/297#discussion_r191377160
+3030,5,1,marcopeereboom,2018-06-11 13:39:48,https://github.com/decred/politeia/pull/271#discussion_r194406694
+3031,5,1,fernandoabolafio,2018-06-11 13:46:22,https://github.com/decred/politeia/pull/271#discussion_r194408936
+3032,5,1,sndurkin,2018-05-31 19:30:43,https://github.com/decred/politeia/pull/281#discussion_r192211779
+3033,5,1,sndurkin,2018-05-31 19:32:42,https://github.com/decred/politeia/pull/281#discussion_r192212233
+3034,5,1,sndurkin,2018-05-31 19:37:49,https://github.com/decred/politeia/pull/281#discussion_r192213391
+3035,5,1,sndurkin,2018-05-31 19:41:51,https://github.com/decred/politeia/pull/281#discussion_r192214432
+3036,5,1,sndurkin,2018-05-31 19:42:59,https://github.com/decred/politeia/pull/281#discussion_r192214724
+3037,5,1,sndurkin,2018-05-31 19:43:33,https://github.com/decred/politeia/pull/281#discussion_r192214853
+3038,5,1,decebal,2018-06-01 08:59:34,https://github.com/decred/politeia/pull/281#discussion_r192336435
+3039,5,1,sndurkin,2018-06-21 16:46:39,https://github.com/decred/politeia/pull/326#discussion_r197203384
+3040,5,1,marcopeereboom,2018-06-25 14:51:26,https://github.com/decred/politeia/pull/341#discussion_r197826358
+3041,5,1,marcopeereboom,2018-06-25 14:53:29,https://github.com/decred/politeia/pull/341#discussion_r197827080
+3042,5,1,marcopeereboom,2018-06-25 14:54:19,https://github.com/decred/politeia/pull/341#discussion_r197827404
+3043,5,1,fernandoabolafio,2018-06-25 16:10:16,https://github.com/decred/politeia/pull/341#discussion_r197853930
+3044,5,1,lukebp,2018-06-25 21:29:18,https://github.com/decred/politeia/pull/352#discussion_r197948361
+3045,5,1,lukebp,2018-06-25 22:37:07,https://github.com/decred/politeia/pull/352#discussion_r197963720
+3046,5,1,lukebp,2018-06-25 22:45:20,https://github.com/decred/politeia/pull/352#discussion_r197965170
+3047,5,1,lukebp,2018-06-25 23:02:44,https://github.com/decred/politeia/pull/352#discussion_r197968796
+3048,5,1,marcopeereboom,2018-06-26 14:11:58,https://github.com/decred/politeia/pull/331#discussion_r198159451
+3049,5,1,marcopeereboom,2018-06-26 14:12:07,https://github.com/decred/politeia/pull/331#discussion_r198159529
+3050,5,1,marcopeereboom,2018-06-26 14:13:36,https://github.com/decred/politeia/pull/331#discussion_r198160167
+3051,5,1,marcopeereboom,2018-06-28 11:14:21,https://github.com/decred/politeia/pull/331#discussion_r198804125
+3052,5,1,marcopeereboom,2018-06-28 13:24:55,https://github.com/decred/politeia/pull/331#discussion_r198838303
+3053,5,1,marcopeereboom,2018-06-28 13:25:38,https://github.com/decred/politeia/pull/331#discussion_r198838526
+3054,5,1,marcopeereboom,2018-06-28 13:26:55,https://github.com/decred/politeia/pull/331#discussion_r198838945
+3055,5,1,marcopeereboom,2018-06-28 13:27:43,https://github.com/decred/politeia/pull/331#discussion_r198839215
+3056,5,1,marcopeereboom,2018-06-28 13:28:02,https://github.com/decred/politeia/pull/331#discussion_r198839300
+3057,5,1,marcopeereboom,2018-06-28 13:29:21,https://github.com/decred/politeia/pull/331#discussion_r198839768
+3058,5,1,marcopeereboom,2018-06-28 13:31:40,https://github.com/decred/politeia/pull/331#discussion_r198840537
+3059,5,1,marcopeereboom,2018-06-28 13:34:09,https://github.com/decred/politeia/pull/331#discussion_r198841405
+3060,5,1,marcopeereboom,2018-06-28 13:35:10,https://github.com/decred/politeia/pull/331#discussion_r198841745
+3061,5,1,marcopeereboom,2018-06-28 13:36:21,https://github.com/decred/politeia/pull/331#discussion_r198842165
+3062,5,1,fernandoabolafio,2018-06-28 16:06:09,https://github.com/decred/politeia/pull/331#discussion_r198898491
+3063,5,1,marcopeereboom,2018-06-28 17:24:24,https://github.com/decred/politeia/pull/331#discussion_r198921644
+3064,5,1,marcopeereboom,2018-06-28 17:25:43,https://github.com/decred/politeia/pull/331#discussion_r198922015
+3065,5,1,chappjc,2018-06-21 16:36:01,https://github.com/decred/politeia/pull/338#discussion_r197200225
+3066,5,1,chappjc,2018-06-21 16:36:24,https://github.com/decred/politeia/pull/338#discussion_r197200325
+3067,5,1,marcopeereboom,2018-06-26 12:11:28,https://github.com/decred/politeia/pull/338#discussion_r198118606
+3068,5,1,marcopeereboom,2018-06-26 12:13:42,https://github.com/decred/politeia/pull/338#discussion_r198119145
+3069,5,1,marcopeereboom,2018-06-26 12:16:51,https://github.com/decred/politeia/pull/338#discussion_r198120059
+3070,5,1,marcopeereboom,2018-06-26 12:17:15,https://github.com/decred/politeia/pull/338#discussion_r198120184
+3071,5,1,marcopeereboom,2018-06-26 12:19:57,https://github.com/decred/politeia/pull/338#discussion_r198120976
+3072,5,1,marcopeereboom,2018-06-28 13:51:32,https://github.com/decred/politeia/pull/338#discussion_r198847577
+3073,5,1,marcopeereboom,2018-06-29 15:18:40,https://github.com/decred/politeia/pull/338#discussion_r199193521
+3074,5,1,sndurkin,2018-06-13 18:32:30,https://github.com/decred/politeia/pull/320#discussion_r195191202
+3075,5,1,sndurkin,2018-06-13 18:34:37,https://github.com/decred/politeia/pull/320#discussion_r195191891
+3076,5,1,lukebp,2018-07-04 01:26:00,https://github.com/decred/politeia/pull/371#discussion_r199988418
+3077,5,1,marcopeereboom,2018-07-13 11:10:02,https://github.com/decred/politeia/pull/386#discussion_r202317764
+3078,5,1,marcopeereboom,2018-07-13 11:10:22,https://github.com/decred/politeia/pull/386#discussion_r202317808
+3079,5,1,marcopeereboom,2018-07-13 11:10:38,https://github.com/decred/politeia/pull/386#discussion_r202317848
+3080,5,1,dajohi,2018-07-17 14:21:23,https://github.com/decred/politeia/pull/387#discussion_r203041425
+3081,5,1,marcopeereboom,2018-07-23 22:27:15,https://github.com/decred/politeia/pull/370#discussion_r204572884
+3082,5,1,marcopeereboom,2018-07-23 22:28:42,https://github.com/decred/politeia/pull/370#discussion_r204573192
+3083,5,1,marcopeereboom,2018-07-23 22:29:06,https://github.com/decred/politeia/pull/370#discussion_r204573269
+3084,5,1,marcopeereboom,2018-07-23 22:29:31,https://github.com/decred/politeia/pull/370#discussion_r204573352
+3085,5,1,marcopeereboom,2018-07-23 22:29:54,https://github.com/decred/politeia/pull/370#discussion_r204573433
+3086,5,1,marcopeereboom,2018-07-23 22:30:12,https://github.com/decred/politeia/pull/370#discussion_r204573488
+3087,5,1,marcopeereboom,2018-07-23 22:31:07,https://github.com/decred/politeia/pull/370#discussion_r204573646
+3088,5,1,fernandoabolafio,2018-07-23 23:44:15,https://github.com/decred/politeia/pull/370#discussion_r204586375
+3089,5,1,sndurkin,2018-07-24 14:24:44,https://github.com/decred/politeia/pull/401#discussion_r204777218
+3090,5,1,hsanjuan,2018-07-24 15:31:22,https://github.com/decred/politeia/pull/401#discussion_r204803980
+3091,5,1,sndurkin,2018-07-24 15:41:07,https://github.com/decred/politeia/pull/401#discussion_r204807751
+3092,5,1,hsanjuan,2018-07-25 11:55:07,https://github.com/decred/politeia/pull/401#discussion_r205079946
+3093,5,1,dajohi,2018-07-25 12:53:23,https://github.com/decred/politeia/pull/401#discussion_r205096068
+3094,5,1,sndurkin,2018-07-21 04:42:31,https://github.com/decred/politeia/pull/394#discussion_r204202076
+3095,5,1,sndurkin,2018-07-21 04:43:58,https://github.com/decred/politeia/pull/394#discussion_r204202103
+3096,5,1,sndurkin,2018-07-21 04:47:19,https://github.com/decred/politeia/pull/394#discussion_r204202247
+3097,5,1,sndurkin,2018-07-21 04:48:12,https://github.com/decred/politeia/pull/394#discussion_r204202255
+3098,5,1,sndurkin,2018-07-21 04:49:01,https://github.com/decred/politeia/pull/394#discussion_r204202265
+3099,5,1,vctt94,2018-07-23 15:48:05,https://github.com/decred/politeia/pull/394#discussion_r204453280
+3100,5,1,marcopeereboom,2018-07-23 16:47:09,https://github.com/decred/politeia/pull/394#discussion_r204476883
+3101,5,1,vctt94,2018-07-23 16:54:06,https://github.com/decred/politeia/pull/394#discussion_r204478930
+3102,5,1,marcopeereboom,2018-07-23 22:22:20,https://github.com/decred/politeia/pull/394#discussion_r204571931
+3103,5,1,marcopeereboom,2018-07-23 22:24:15,https://github.com/decred/politeia/pull/394#discussion_r204572294
+3104,5,1,sndurkin,2018-07-23 22:31:37,https://github.com/decred/politeia/pull/394#discussion_r204573725
+3105,5,1,sndurkin,2018-07-23 22:34:07,https://github.com/decred/politeia/pull/394#discussion_r204574213
+3106,5,1,sndurkin,2018-07-23 22:35:49,https://github.com/decred/politeia/pull/394#discussion_r204574518
+3107,5,1,dajohi,2018-07-24 13:46:23,https://github.com/decred/politeia/pull/394#discussion_r204761272
+3108,5,1,dajohi,2018-07-24 13:47:43,https://github.com/decred/politeia/pull/394#discussion_r204761828
+3109,5,1,marcopeereboom,2018-07-23 22:15:23,https://github.com/decred/politeia/pull/389#discussion_r204570562
+3110,5,1,sndurkin,2018-07-27 15:11:26,https://github.com/decred/politeia/pull/400#discussion_r205807322
+3111,5,1,sndurkin,2018-07-27 15:11:37,https://github.com/decred/politeia/pull/400#discussion_r205807379
+3112,5,1,fernandoabolafio,2018-07-27 16:57:04,https://github.com/decred/politeia/pull/400#discussion_r205836781
+3113,5,1,sndurkin,2018-07-21 04:52:04,https://github.com/decred/politeia/pull/393#discussion_r204202313
+3114,5,1,sndurkin,2018-07-21 04:52:55,https://github.com/decred/politeia/pull/393#discussion_r204202321
+3115,5,1,sndurkin,2018-07-21 04:53:15,https://github.com/decred/politeia/pull/393#discussion_r204202329
+3116,5,1,sndurkin,2018-07-21 04:54:05,https://github.com/decred/politeia/pull/393#discussion_r204202343
+3117,5,1,sndurkin,2018-07-21 04:59:11,https://github.com/decred/politeia/pull/393#discussion_r204202443
+3118,5,1,fernandoabolafio,2018-07-21 11:57:20,https://github.com/decred/politeia/pull/393#discussion_r204209170
+3119,5,1,sndurkin,2018-07-21 13:32:47,https://github.com/decred/politeia/pull/393#discussion_r204211008
+3120,5,1,sndurkin,2018-08-01 03:56:10,https://github.com/decred/politeia/pull/393#discussion_r206749107
+3121,5,1,sndurkin,2018-08-01 04:07:22,https://github.com/decred/politeia/pull/393#discussion_r206750252
+3122,5,1,sndurkin,2018-08-01 04:15:32,https://github.com/decred/politeia/pull/393#discussion_r206751023
+3123,5,1,fernandoabolafio,2018-08-01 16:54:56,https://github.com/decred/politeia/pull/393#discussion_r206955461
+3124,5,1,dajohi,2018-08-31 13:18:32,https://github.com/decred/politeia/pull/435#discussion_r214350041
+3125,5,1,marcopeereboom,2018-09-04 20:16:32,https://github.com/decred/politeia/pull/439#discussion_r215052348
+3126,5,1,marcopeereboom,2018-09-04 20:16:57,https://github.com/decred/politeia/pull/439#discussion_r215052465
+3127,5,1,marcopeereboom,2018-09-04 20:17:07,https://github.com/decred/politeia/pull/439#discussion_r215052510
+3128,5,1,marcopeereboom,2018-09-04 20:17:43,https://github.com/decred/politeia/pull/439#discussion_r215052671
+3129,5,1,marcopeereboom,2018-09-04 20:20:03,https://github.com/decred/politeia/pull/439#discussion_r215053299
+3130,5,1,marcopeereboom,2018-09-04 20:20:31,https://github.com/decred/politeia/pull/439#discussion_r215053451
+3131,5,1,marcopeereboom,2018-09-04 20:38:00,https://github.com/decred/politeia/pull/440#discussion_r215058739
+3132,5,1,marcopeereboom,2018-09-05 12:48:11,https://github.com/decred/politeia/pull/442#discussion_r215254853
+3133,5,1,lukebp,2018-09-05 12:57:14,https://github.com/decred/politeia/pull/442#discussion_r215257682
+3134,5,1,dajohi,2018-08-30 14:49:08,https://github.com/decred/politeia/pull/374#discussion_r214061321
+3135,5,1,dajohi,2018-09-06 14:46:23,https://github.com/decred/politeia/pull/374#discussion_r215654136
+3136,5,1,lukebp,2018-09-07 16:24:35,https://github.com/decred/politeia/pull/457#discussion_r216014972
+3137,5,1,marcopeereboom,2018-08-14 12:54:19,https://github.com/decred/politeia/pull/423#discussion_r209938869
+3138,5,1,marcopeereboom,2018-08-14 12:55:52,https://github.com/decred/politeia/pull/423#discussion_r209939375
+3139,5,1,lukebp,2018-08-16 12:55:54,https://github.com/decred/politeia/pull/423#discussion_r210583545
+3140,5,1,marcopeereboom,2018-09-14 15:23:23,https://github.com/decred/politeia/pull/423#discussion_r217750341
+3141,5,1,marcopeereboom,2018-09-14 15:24:16,https://github.com/decred/politeia/pull/423#discussion_r217750670
+3142,5,1,sndurkin,2018-09-26 13:06:39,https://github.com/decred/politeia/pull/484#discussion_r220552712
+3143,5,1,sndurkin,2018-09-27 15:29:06,https://github.com/decred/politeia/pull/465#discussion_r220970750
+3144,5,1,sndurkin,2018-09-27 15:30:07,https://github.com/decred/politeia/pull/465#discussion_r220971152
+3145,5,1,sndurkin,2018-09-27 15:32:14,https://github.com/decred/politeia/pull/465#discussion_r220971951
+3146,5,1,lukebp,2018-09-27 16:16:42,https://github.com/decred/politeia/pull/465#discussion_r220987829
+3147,5,1,fernandoabolafio,2018-09-27 16:22:35,https://github.com/decred/politeia/pull/465#discussion_r220989903
+3148,5,1,fernandoabolafio,2018-09-27 16:29:24,https://github.com/decred/politeia/pull/465#discussion_r220992439
+3149,5,1,fernandoabolafio,2018-09-27 16:29:59,https://github.com/decred/politeia/pull/465#discussion_r220992632
+3150,5,1,lukebp,2018-09-27 16:41:16,https://github.com/decred/politeia/pull/465#discussion_r220996230
+3151,5,1,marcopeereboom,2018-09-27 16:54:28,https://github.com/decred/politeia/pull/465#discussion_r221000235
+3152,5,1,marcopeereboom,2018-09-27 16:56:07,https://github.com/decred/politeia/pull/465#discussion_r221000755
+3153,5,1,marcopeereboom,2018-09-27 16:57:25,https://github.com/decred/politeia/pull/465#discussion_r221001174
+3154,5,1,marcopeereboom,2018-09-27 16:58:01,https://github.com/decred/politeia/pull/465#discussion_r221001382
+3155,5,1,marcopeereboom,2018-09-27 17:00:29,https://github.com/decred/politeia/pull/465#discussion_r221002139
+3156,5,1,marcopeereboom,2018-09-27 17:02:54,https://github.com/decred/politeia/pull/465#discussion_r221002901
+3157,5,1,marcopeereboom,2018-09-27 17:03:49,https://github.com/decred/politeia/pull/465#discussion_r221003187
+3158,5,1,marcopeereboom,2018-09-27 17:03:57,https://github.com/decred/politeia/pull/465#discussion_r221003220
+3159,5,1,lukebp,2018-09-27 17:07:57,https://github.com/decred/politeia/pull/465#discussion_r221004389
+3160,5,1,lukebp,2018-09-26 20:15:44,https://github.com/decred/politeia/pull/487#discussion_r220707952
+3161,5,1,marcopeereboom,2018-09-27 22:07:33,https://github.com/decred/politeia/pull/491#discussion_r221092535
+3162,5,1,marcopeereboom,2018-09-27 22:08:37,https://github.com/decred/politeia/pull/491#discussion_r221092724
+3163,5,1,marcopeereboom,2018-09-27 22:12:11,https://github.com/decred/politeia/pull/491#discussion_r221093421
+3164,5,1,marcopeereboom,2018-09-27 22:13:11,https://github.com/decred/politeia/pull/491#discussion_r221093598
+3165,5,1,marcopeereboom,2018-09-27 22:14:20,https://github.com/decred/politeia/pull/491#discussion_r221093833
+3166,5,1,marcopeereboom,2018-09-27 22:15:32,https://github.com/decred/politeia/pull/491#discussion_r221094059
+3167,5,1,fernandoabolafio,2018-09-27 22:21:59,https://github.com/decred/politeia/pull/491#discussion_r221095334
+3168,5,1,marcopeereboom,2018-10-02 14:11:40,https://github.com/decred/politeia/pull/495#discussion_r221966622
+3169,5,1,marcopeereboom,2018-10-02 14:12:08,https://github.com/decred/politeia/pull/495#discussion_r221966809
+3170,5,1,marcopeereboom,2018-10-02 14:12:34,https://github.com/decred/politeia/pull/495#discussion_r221966961
+3171,5,1,marcopeereboom,2018-10-02 20:25:53,https://github.com/decred/politeia/pull/496#discussion_r222099381
+3172,5,1,marcopeereboom,2018-10-02 20:26:10,https://github.com/decred/politeia/pull/496#discussion_r222099467
+3173,5,1,lukebp,2018-10-05 13:17:54,https://github.com/decred/politeia/pull/504#discussion_r223002047
+3174,5,1,fernandoabolafio,2018-10-08 17:12:17,https://github.com/decred/politeia/pull/510#discussion_r223437506
+3175,5,1,fernandoabolafio,2018-10-08 17:13:49,https://github.com/decred/politeia/pull/510#discussion_r223437918
+3176,5,1,fernandoabolafio,2018-10-08 17:16:28,https://github.com/decred/politeia/pull/510#discussion_r223438632
+3177,5,1,lukebp,2018-10-08 18:56:26,https://github.com/decred/politeia/pull/510#discussion_r223465784
+3178,5,1,lukebp,2018-10-08 19:01:56,https://github.com/decred/politeia/pull/510#discussion_r223467255
+3179,5,1,lukebp,2018-10-08 19:02:19,https://github.com/decred/politeia/pull/510#discussion_r223467359
+3180,5,1,lukebp,2018-10-09 11:50:39,https://github.com/decred/politeia/pull/510#discussion_r223667151
+3181,5,1,davecgh,2018-10-15 17:40:12,https://github.com/decred/politeia/pull/519#discussion_r225255313
+3182,5,1,davecgh,2018-10-15 17:40:18,https://github.com/decred/politeia/pull/519#discussion_r225255343
+3183,5,1,davecgh,2018-10-15 17:58:07,https://github.com/decred/politeia/pull/519#discussion_r225261083
+3184,5,1,dajohi,2018-10-16 16:49:22,https://github.com/decred/politeia/pull/529#discussion_r225622210
+3185,5,1,dajohi,2018-10-16 16:49:55,https://github.com/decred/politeia/pull/529#discussion_r225622384
+3186,5,1,dajohi,2018-10-16 16:50:07,https://github.com/decred/politeia/pull/529#discussion_r225622450
+3187,5,1,dajohi,2018-10-16 16:50:24,https://github.com/decred/politeia/pull/529#discussion_r225622554
+3188,5,1,dajohi,2018-10-16 16:50:34,https://github.com/decred/politeia/pull/529#discussion_r225622599
+3189,5,1,sndurkin,2018-10-16 18:46:23,https://github.com/decred/politeia/pull/530#discussion_r225664324
+3190,5,1,fernandoabolafio,2018-10-16 18:56:06,https://github.com/decred/politeia/pull/530#discussion_r225667585
+3191,5,1,sndurkin,2018-10-16 18:59:08,https://github.com/decred/politeia/pull/530#discussion_r225668617
+3192,5,1,lukebp,2018-10-17 11:43:20,https://github.com/decred/politeia/pull/532#discussion_r225889360
+3193,5,1,lukebp,2018-10-17 11:46:51,https://github.com/decred/politeia/pull/532#discussion_r225890318
+3194,5,1,lukebp,2018-10-17 12:14:20,https://github.com/decred/politeia/pull/532#discussion_r225899833
+3195,5,1,lukebp,2018-10-17 12:25:14,https://github.com/decred/politeia/pull/532#discussion_r225903484
+3196,5,1,lukebp,2018-10-17 12:31:20,https://github.com/decred/politeia/pull/532#discussion_r225906523
+3197,5,1,lukebp,2018-10-17 12:35:54,https://github.com/decred/politeia/pull/532#discussion_r225907996
+3198,5,1,sndurkin,2018-10-17 13:23:02,https://github.com/decred/politeia/pull/532#discussion_r225925255
+3199,5,1,sndurkin,2018-10-17 13:24:14,https://github.com/decred/politeia/pull/532#discussion_r225925687
+3200,5,1,sndurkin,2018-10-17 13:25:39,https://github.com/decred/politeia/pull/532#discussion_r225926278
+3201,5,1,lukebp,2018-10-17 13:34:34,https://github.com/decred/politeia/pull/532#discussion_r225929887
+3202,5,1,lukebp,2018-10-17 13:37:34,https://github.com/decred/politeia/pull/532#discussion_r225931218
+3203,5,1,lukebp,2018-10-17 13:44:37,https://github.com/decred/politeia/pull/532#discussion_r225934308
+3204,5,1,marcopeereboom,2018-10-17 14:52:36,https://github.com/decred/politeia/pull/532#discussion_r225964650
+3205,5,1,marcopeereboom,2018-10-17 14:54:50,https://github.com/decred/politeia/pull/532#discussion_r225965675
+3206,5,1,marcopeereboom,2018-10-17 14:55:34,https://github.com/decred/politeia/pull/532#discussion_r225965983
+3207,5,1,lukebp,2018-10-02 23:26:23,https://github.com/decred/politeia/pull/494#discussion_r222142361
+3208,5,1,wallclockbuilder,2018-10-04 05:36:57,https://github.com/decred/politeia/pull/494#discussion_r222542304
+3209,5,1,lukebp,2018-10-17 15:11:07,https://github.com/decred/politeia/pull/494#discussion_r225973068
+3210,5,1,lukebp,2018-10-17 15:14:36,https://github.com/decred/politeia/pull/494#discussion_r225975549
+3211,5,1,sndurkin,2018-10-16 18:56:49,https://github.com/decred/politeia/pull/430#discussion_r225667810
+3212,5,1,marcopeereboom,2018-10-22 21:31:23,https://github.com/decred/politeia/pull/552#discussion_r227145824
+3213,5,1,marcopeereboom,2018-10-22 22:03:14,https://github.com/decred/politeia/pull/552#discussion_r227154459
+3214,5,1,lukebp,2018-10-23 16:07:51,https://github.com/decred/politeia/pull/552#discussion_r227462544
+3215,5,1,lukebp,2018-10-23 16:08:13,https://github.com/decred/politeia/pull/552#discussion_r227462686
+3216,5,1,davecgh,2018-11-01 16:46:54,https://github.com/decred/politeia/pull/574#discussion_r230112500
+3217,5,1,davecgh,2018-11-01 16:48:25,https://github.com/decred/politeia/pull/574#discussion_r230113037
+3218,5,1,marcopeereboom,2018-11-01 16:49:07,https://github.com/decred/politeia/pull/574#discussion_r230113288
+3219,5,1,lukebp,2018-11-01 17:01:15,https://github.com/decred/politeia/pull/574#discussion_r230117541
+3220,5,1,davecgh,2018-11-01 17:19:45,https://github.com/decred/politeia/pull/574#discussion_r230124155
+3221,5,1,lukebp,2018-11-01 18:50:30,https://github.com/decred/politeia/pull/574#discussion_r230156206
+3222,5,1,lukebp,2018-11-01 18:51:11,https://github.com/decred/politeia/pull/574#discussion_r230156448
+3223,5,1,lukebp,2018-11-01 18:59:36,https://github.com/decred/politeia/pull/574#discussion_r230159289
+3224,5,1,davecgh,2018-11-01 17:32:47,https://github.com/decred/politeia/pull/574#discussion_r230128843
+3225,5,1,davecgh,2018-10-30 16:05:41,https://github.com/decred/politeia/pull/566#discussion_r229372651
+3226,5,1,davecgh,2018-11-02 04:44:15,https://github.com/decred/politeia/pull/577#discussion_r230268842
+3227,5,1,davecgh,2018-11-02 04:50:45,https://github.com/decred/politeia/pull/577#discussion_r230269495
+3228,5,1,lukebp,2018-11-05 15:16:59,https://github.com/decred/politeia/pull/577#discussion_r230787631
+3229,5,1,lukebp,2018-11-05 15:44:31,https://github.com/decred/politeia/pull/577#discussion_r230798845
+3230,5,1,fernandoabolafio,2018-11-05 16:19:38,https://github.com/decred/politeia/pull/577#discussion_r230813810
+3231,5,1,lukebp,2018-11-05 16:28:02,https://github.com/decred/politeia/pull/577#discussion_r230817538
+3232,5,1,lukebp,2018-11-05 17:21:48,https://github.com/decred/politeia/pull/577#discussion_r230838216
+3233,5,1,sndurkin,2018-11-06 04:05:16,https://github.com/decred/politeia/pull/577#discussion_r230993953
+3234,5,1,lukebp,2018-11-12 14:36:40,https://github.com/decred/politeia/pull/577#discussion_r232680345
+3235,5,1,lukebp,2018-11-12 14:56:37,https://github.com/decred/politeia/pull/577#discussion_r232688668
+3236,5,1,lukebp,2018-11-12 15:42:19,https://github.com/decred/politeia/pull/577#discussion_r232706782
+3237,5,1,lukebp,2018-11-12 15:44:49,https://github.com/decred/politeia/pull/577#discussion_r232707816
+3238,5,1,lukebp,2018-11-13 17:06:41,https://github.com/decred/politeia/pull/577#discussion_r233137174
+3239,5,1,marcopeereboom,2018-11-13 17:14:56,https://github.com/decred/politeia/pull/577#discussion_r233140537
+3240,5,1,marcopeereboom,2018-11-13 17:15:56,https://github.com/decred/politeia/pull/577#discussion_r233140893
+3241,5,1,marcopeereboom,2018-11-13 17:17:23,https://github.com/decred/politeia/pull/577#discussion_r233141448
+3242,5,1,sndurkin,2018-11-14 14:20:41,https://github.com/decred/politeia/pull/577#discussion_r233465294
+3243,5,1,sndurkin,2018-11-14 14:21:04,https://github.com/decred/politeia/pull/577#discussion_r233465454
+3244,5,1,sndurkin,2018-11-14 14:21:27,https://github.com/decred/politeia/pull/577#discussion_r233465617
+3245,5,1,lukebp,2018-11-13 20:45:31,https://github.com/decred/politeia/pull/595#discussion_r233215072
+3246,5,1,thi4go,2018-11-14 10:45:00,https://github.com/decred/politeia/pull/595#discussion_r233396386
+3247,5,1,brunobraga95,2018-11-21 17:33:58,https://github.com/decred/politeia/pull/613#discussion_r235480808
+3248,5,1,brunobraga95,2018-11-21 17:34:23,https://github.com/decred/politeia/pull/613#discussion_r235480955
+3249,5,1,brunobraga95,2018-11-21 17:34:36,https://github.com/decred/politeia/pull/613#discussion_r235481013
+3250,5,1,brunobraga95,2018-11-21 17:38:51,https://github.com/decred/politeia/pull/613#discussion_r235482292
+3251,5,1,brunobraga95,2018-11-21 17:40:30,https://github.com/decred/politeia/pull/613#discussion_r235482812
+3252,5,1,brunobraga95,2018-11-21 17:41:04,https://github.com/decred/politeia/pull/613#discussion_r235483000
+3253,5,1,brunobraga95,2018-11-21 17:44:34,https://github.com/decred/politeia/pull/613#discussion_r235484143
+3254,5,1,fernandoabolafio,2018-11-21 19:29:15,https://github.com/decred/politeia/pull/613#discussion_r235514903
+3255,5,1,fernandoabolafio,2018-11-21 19:30:50,https://github.com/decred/politeia/pull/613#discussion_r235515295
+3256,5,1,brunobraga95,2018-11-21 20:55:28,https://github.com/decred/politeia/pull/613#discussion_r235536188
+3257,5,1,fernandoabolafio,2018-11-22 12:12:25,https://github.com/decred/politeia/pull/613#discussion_r235703869
+3258,5,1,lukebp,2018-11-22 17:06:11,https://github.com/decred/politeia/pull/613#discussion_r235788792
+3259,5,1,lukebp,2018-11-22 17:13:14,https://github.com/decred/politeia/pull/613#discussion_r235790186
+3260,5,1,lukebp,2018-11-22 17:22:52,https://github.com/decred/politeia/pull/613#discussion_r235791864
+3261,5,1,lukebp,2018-11-22 17:33:43,https://github.com/decred/politeia/pull/613#discussion_r235793750
+3262,5,1,fernandoabolafio,2018-11-22 19:12:23,https://github.com/decred/politeia/pull/613#discussion_r235806206
+3263,5,1,lukebp,2018-11-23 14:16:08,https://github.com/decred/politeia/pull/613#discussion_r235952945
+3264,5,1,fernandoabolafio,2018-11-23 16:06:54,https://github.com/decred/politeia/pull/613#discussion_r235982000
+3265,5,1,marcopeereboom,2018-11-29 19:24:20,https://github.com/decred/politeia/pull/613#discussion_r237625637
+3266,5,1,lukebp,2018-11-26 23:57:27,https://github.com/decred/politeia/pull/617#discussion_r236474540
+3267,5,1,lukebp,2018-11-26 23:59:37,https://github.com/decred/politeia/pull/617#discussion_r236474996
+3268,5,1,lukebp,2018-11-27 00:01:16,https://github.com/decred/politeia/pull/617#discussion_r236475333
+3269,5,1,thi4go,2018-11-28 23:04:00,https://github.com/decred/politeia/pull/617#discussion_r237296695
+3270,5,1,thi4go,2018-11-28 23:04:12,https://github.com/decred/politeia/pull/617#discussion_r237296758
+3271,5,1,fernandoabolafio,2018-11-18 12:17:03,https://github.com/decred/politeia/pull/606#discussion_r234441969
+3272,5,1,fernandoabolafio,2018-11-18 12:18:20,https://github.com/decred/politeia/pull/606#discussion_r234442024
+3273,5,1,fernandoabolafio,2018-11-18 12:21:53,https://github.com/decred/politeia/pull/606#discussion_r234442172
+3274,5,1,fernandoabolafio,2018-11-18 12:23:02,https://github.com/decred/politeia/pull/606#discussion_r234442210
+3275,5,1,fernandoabolafio,2018-11-18 12:24:06,https://github.com/decred/politeia/pull/606#discussion_r234442262
+3276,5,1,fernandoabolafio,2018-11-18 12:31:21,https://github.com/decred/politeia/pull/606#discussion_r234442549
+3277,5,1,fernandoabolafio,2018-11-18 12:32:27,https://github.com/decred/politeia/pull/606#discussion_r234442585
+3278,5,1,fernandoabolafio,2018-11-18 12:36:35,https://github.com/decred/politeia/pull/606#discussion_r234442749
+3279,5,1,fernandoabolafio,2018-11-21 17:59:41,https://github.com/decred/politeia/pull/606#discussion_r235489341
+3280,5,1,victorgcramos,2018-11-21 18:33:46,https://github.com/decred/politeia/pull/606#discussion_r235498937
+3281,5,1,lukebp,2018-11-21 18:58:24,https://github.com/decred/politeia/pull/606#discussion_r235506166
+3282,5,1,lukebp,2018-11-22 19:48:09,https://github.com/decred/politeia/pull/606#discussion_r235810052
+3283,5,1,lukebp,2018-11-22 19:57:41,https://github.com/decred/politeia/pull/606#discussion_r235811143
+3284,5,1,lukebp,2018-11-22 20:10:43,https://github.com/decred/politeia/pull/606#discussion_r235812617
+3285,5,1,tiagoalvesdulce,2018-11-22 20:11:03,https://github.com/decred/politeia/pull/606#discussion_r235812662
+3286,5,1,lukebp,2018-11-23 14:23:29,https://github.com/decred/politeia/pull/606#discussion_r235954981
+3287,5,1,lukebp,2018-11-23 14:31:58,https://github.com/decred/politeia/pull/606#discussion_r235957392
+3288,5,1,lukebp,2018-11-23 14:40:05,https://github.com/decred/politeia/pull/606#discussion_r235959542
+3289,5,1,lukebp,2018-11-23 14:42:54,https://github.com/decred/politeia/pull/606#discussion_r235960270
+3290,5,1,lukebp,2018-11-23 14:43:55,https://github.com/decred/politeia/pull/606#discussion_r235960597
+3291,5,1,lukebp,2018-11-23 15:06:38,https://github.com/decred/politeia/pull/606#discussion_r235966543
+3292,5,1,lukebp,2018-11-23 15:07:51,https://github.com/decred/politeia/pull/606#discussion_r235966904
+3293,5,1,lukebp,2018-11-23 15:08:44,https://github.com/decred/politeia/pull/606#discussion_r235967140
+3294,5,1,lukebp,2018-11-23 15:11:48,https://github.com/decred/politeia/pull/606#discussion_r235967921
+3295,5,1,victorgcramos,2018-11-23 16:36:41,https://github.com/decred/politeia/pull/606#discussion_r235988498
+3296,5,1,sndurkin,2018-11-30 02:14:34,https://github.com/decred/politeia/pull/606#discussion_r237726194
+3297,5,1,sndurkin,2018-11-30 02:14:52,https://github.com/decred/politeia/pull/606#discussion_r237726236
+3298,5,1,sndurkin,2018-11-30 02:17:32,https://github.com/decred/politeia/pull/606#discussion_r237726620
+3299,5,1,sndurkin,2018-11-30 02:22:10,https://github.com/decred/politeia/pull/606#discussion_r237727247
+3300,5,1,sndurkin,2018-11-30 02:22:22,https://github.com/decred/politeia/pull/606#discussion_r237727273
+3301,5,1,victorgcramos,2018-11-30 19:25:30,https://github.com/decred/politeia/pull/606#discussion_r237974939
+3302,5,1,sndurkin,2018-11-30 19:51:54,https://github.com/decred/politeia/pull/606#discussion_r237982979
+3303,5,1,marcopeereboom,2018-11-30 20:04:48,https://github.com/decred/politeia/pull/606#discussion_r237986736
+3304,5,1,marcopeereboom,2018-11-30 20:06:23,https://github.com/decred/politeia/pull/606#discussion_r237987143
+3305,5,1,marcopeereboom,2018-11-30 20:07:34,https://github.com/decred/politeia/pull/606#discussion_r237987502
+3306,5,1,lukebp,2018-11-30 20:50:05,https://github.com/decred/politeia/pull/606#discussion_r237998189
+3307,5,1,lukebp,2018-11-30 20:57:52,https://github.com/decred/politeia/pull/606#discussion_r238000035
+3308,5,1,lukebp,2018-11-30 20:59:44,https://github.com/decred/politeia/pull/606#discussion_r238000539
+3309,5,1,lukebp,2018-11-30 12:32:55,https://github.com/decred/politeia/pull/625#discussion_r237845222
+3310,5,1,lukebp,2018-11-30 12:34:51,https://github.com/decred/politeia/pull/625#discussion_r237845653
+3311,5,1,lukebp,2018-11-30 12:38:16,https://github.com/decred/politeia/pull/625#discussion_r237846511
+3312,5,1,lukebp,2018-11-30 12:38:52,https://github.com/decred/politeia/pull/625#discussion_r237846668
+3313,5,1,s-ben,2018-11-30 20:17:08,https://github.com/decred/politeia/pull/625#discussion_r237990061
+3314,5,1,s-ben,2018-11-30 20:17:26,https://github.com/decred/politeia/pull/625#discussion_r237990178
+3315,5,1,s-ben,2018-11-30 20:20:53,https://github.com/decred/politeia/pull/625#discussion_r237991272
+3316,5,1,s-ben,2018-11-30 20:21:06,https://github.com/decred/politeia/pull/625#discussion_r237991352
+3317,5,1,lukebp,2018-11-21 13:23:46,https://github.com/decred/politeia/pull/610#discussion_r235384573
+3318,5,1,lukebp,2018-11-21 13:27:32,https://github.com/decred/politeia/pull/610#discussion_r235385879
+3319,5,1,lukebp,2018-11-21 13:42:20,https://github.com/decred/politeia/pull/610#discussion_r235390761
+3320,5,1,lukebp,2018-11-21 14:10:18,https://github.com/decred/politeia/pull/610#discussion_r235400906
+3321,5,1,lukebp,2018-11-21 14:36:58,https://github.com/decred/politeia/pull/610#discussion_r235411185
+3322,5,1,lukebp,2018-11-21 14:38:48,https://github.com/decred/politeia/pull/610#discussion_r235411891
+3323,5,1,lukebp,2018-11-21 14:40:05,https://github.com/decred/politeia/pull/610#discussion_r235412387
+3324,5,1,lukebp,2018-11-21 14:41:07,https://github.com/decred/politeia/pull/610#discussion_r235412768
+3325,5,1,lukebp,2018-11-21 14:41:27,https://github.com/decred/politeia/pull/610#discussion_r235412890
+3326,5,1,lukebp,2018-11-21 14:42:13,https://github.com/decred/politeia/pull/610#discussion_r235413206
+3327,5,1,lukebp,2018-11-21 14:42:31,https://github.com/decred/politeia/pull/610#discussion_r235413312
+3328,5,1,lukebp,2018-11-21 14:45:15,https://github.com/decred/politeia/pull/610#discussion_r235414457
+3329,5,1,lukebp,2018-11-21 14:46:48,https://github.com/decred/politeia/pull/610#discussion_r235415088
+3330,5,1,lukebp,2018-11-21 14:49:45,https://github.com/decred/politeia/pull/610#discussion_r235416233
+3331,5,1,fernandoabolafio,2018-11-21 16:45:23,https://github.com/decred/politeia/pull/610#discussion_r235464047
+3332,5,1,lukebp,2018-11-21 17:46:34,https://github.com/decred/politeia/pull/610#discussion_r235484820
+3333,5,1,marcopeereboom,2018-11-30 14:28:41,https://github.com/decred/politeia/pull/610#discussion_r237877727
+3334,5,1,marcopeereboom,2018-11-30 14:29:59,https://github.com/decred/politeia/pull/610#discussion_r237878156
+3335,5,1,marcopeereboom,2018-11-30 14:32:24,https://github.com/decred/politeia/pull/610#discussion_r237878916
+3336,5,1,marcopeereboom,2018-11-30 14:32:54,https://github.com/decred/politeia/pull/610#discussion_r237879101
+3337,5,1,fernandoabolafio,2018-11-30 15:07:57,https://github.com/decred/politeia/pull/610#discussion_r237891229
+3338,5,1,fernandoabolafio,2018-11-30 15:13:41,https://github.com/decred/politeia/pull/610#discussion_r237893383
+3339,5,1,fernandoabolafio,2018-11-30 15:18:48,https://github.com/decred/politeia/pull/610#discussion_r237895163
+3340,5,1,fernandoabolafio,2018-11-30 15:24:30,https://github.com/decred/politeia/pull/610#discussion_r237897133
+3341,5,1,marcopeereboom,2018-11-30 15:28:03,https://github.com/decred/politeia/pull/610#discussion_r237898355
+3342,5,1,marcopeereboom,2018-11-30 15:28:30,https://github.com/decred/politeia/pull/610#discussion_r237898521
+3343,5,1,marcopeereboom,2018-11-30 15:28:57,https://github.com/decred/politeia/pull/610#discussion_r237898658
+3344,5,1,fernandoabolafio,2018-11-30 15:42:00,https://github.com/decred/politeia/pull/610#discussion_r237903160
+3345,5,1,fernandoabolafio,2018-12-03 13:06:15,https://github.com/decred/politeia/pull/610#discussion_r238260349
+3346,5,1,fernandoabolafio,2018-12-03 13:07:02,https://github.com/decred/politeia/pull/610#discussion_r238260567
+3347,5,1,fernandoabolafio,2018-12-03 13:07:36,https://github.com/decred/politeia/pull/610#discussion_r238260733
+3348,5,1,lukebp,2018-12-06 11:27:36,https://github.com/decred/politeia/pull/634#discussion_r239418251
+3349,5,1,lukebp,2018-12-06 11:27:53,https://github.com/decred/politeia/pull/634#discussion_r239418350
+3350,5,1,lukebp,2018-12-07 11:45:35,https://github.com/decred/politeia/pull/635#discussion_r239781105
+3351,5,1,lukebp,2018-12-07 12:09:23,https://github.com/decred/politeia/pull/635#discussion_r239786542
+3352,5,1,thi4go,2018-12-07 14:05:27,https://github.com/decred/politeia/pull/635#discussion_r239817845
+3353,5,1,lukebp,2018-12-10 12:52:55,https://github.com/decred/politeia/pull/624#discussion_r240197798
+3354,5,1,lukebp,2018-12-10 12:53:20,https://github.com/decred/politeia/pull/624#discussion_r240197913
+3355,5,1,lukebp,2018-12-10 12:54:08,https://github.com/decred/politeia/pull/624#discussion_r240198161
+3356,5,1,lukebp,2018-12-10 15:02:01,https://github.com/decred/politeia/pull/624#discussion_r240244142
+3357,5,1,brunobraga95,2018-12-10 15:16:19,https://github.com/decred/politeia/pull/624#discussion_r240250103
+3358,5,1,lukebp,2018-12-10 15:20:42,https://github.com/decred/politeia/pull/624#discussion_r240252066
+3359,5,1,brunobraga95,2018-12-10 15:39:57,https://github.com/decred/politeia/pull/624#discussion_r240260599
+3360,5,1,brunobraga95,2018-12-12 15:14:02,https://github.com/decred/politeia/pull/641#discussion_r241053706
+3361,5,1,lukebp,2018-12-12 22:04:50,https://github.com/decred/politeia/pull/641#discussion_r241202666
+3362,5,1,lukebp,2018-12-09 11:29:59,https://github.com/decred/politeia/pull/640#discussion_r240033180
+3363,5,1,lukebp,2018-12-09 11:30:23,https://github.com/decred/politeia/pull/640#discussion_r240033192
+3364,5,1,lukebp,2018-12-09 11:39:30,https://github.com/decred/politeia/pull/640#discussion_r240033423
+3365,5,1,lukebp,2018-12-09 11:40:32,https://github.com/decred/politeia/pull/640#discussion_r240033446
+3366,5,1,lukebp,2018-12-09 11:41:38,https://github.com/decred/politeia/pull/640#discussion_r240033475
+3367,5,1,lukebp,2018-12-09 11:46:41,https://github.com/decred/politeia/pull/640#discussion_r240033593
+3368,5,1,lukebp,2018-12-09 11:52:12,https://github.com/decred/politeia/pull/640#discussion_r240033735
+3369,5,1,lukebp,2018-12-09 11:53:37,https://github.com/decred/politeia/pull/640#discussion_r240033768
+3370,5,1,brunobraga95,2018-12-10 15:09:10,https://github.com/decred/politeia/pull/640#discussion_r240247097
+3371,5,1,s-ben,2018-12-11 02:28:33,https://github.com/decred/politeia/pull/640#discussion_r240454101
+3372,5,1,s-ben,2018-12-11 02:53:55,https://github.com/decred/politeia/pull/640#discussion_r240457858
+3373,5,1,s-ben,2018-12-11 03:21:34,https://github.com/decred/politeia/pull/640#discussion_r240461772
+3374,5,1,s-ben,2018-12-11 03:42:18,https://github.com/decred/politeia/pull/640#discussion_r240464584
+3375,5,1,s-ben,2018-12-11 03:45:09,https://github.com/decred/politeia/pull/640#discussion_r240465025
+3376,5,1,lukebp,2018-12-12 21:44:23,https://github.com/decred/politeia/pull/640#discussion_r241196451
+3377,5,1,lukebp,2018-12-12 21:44:33,https://github.com/decred/politeia/pull/640#discussion_r241196512
+3378,5,1,lukebp,2018-12-12 21:44:42,https://github.com/decred/politeia/pull/640#discussion_r241196550
+3379,5,1,lukebp,2018-12-12 21:45:28,https://github.com/decred/politeia/pull/640#discussion_r241196771
+3380,5,1,lukebp,2018-12-12 21:49:21,https://github.com/decred/politeia/pull/640#discussion_r241197932
+3381,5,1,lukebp,2018-12-12 21:52:26,https://github.com/decred/politeia/pull/640#discussion_r241198883
+3382,5,1,lukebp,2018-12-12 21:52:39,https://github.com/decred/politeia/pull/640#discussion_r241198953
+3383,5,1,s-ben,2018-12-13 06:03:49,https://github.com/decred/politeia/pull/640#discussion_r241280209
+3384,5,1,s-ben,2018-12-13 06:11:55,https://github.com/decred/politeia/pull/640#discussion_r241281606
+3385,5,1,s-ben,2018-12-13 06:14:40,https://github.com/decred/politeia/pull/640#discussion_r241281956
+3386,5,1,s-ben,2018-12-13 06:16:44,https://github.com/decred/politeia/pull/640#discussion_r241282281
+3387,5,1,lukebp,2018-12-13 21:12:07,https://github.com/decred/politeia/pull/640#discussion_r241562767
+3388,5,1,lukebp,2018-12-26 19:52:11,https://github.com/decred/politeia/pull/649#discussion_r244041571
+3389,5,1,lukebp,2019-01-16 18:49:15,https://github.com/decred/politeia/pull/668#discussion_r248406824
+3390,5,1,marcopeereboom,2019-01-16 19:34:37,https://github.com/decred/politeia/pull/668#discussion_r248421590
+3391,5,1,jholdstock,2019-01-29 15:22:07,https://github.com/decred/politeia/pull/680#discussion_r251878624
+3392,5,1,thi4go,2019-02-04 09:45:52,https://github.com/decred/politeia/pull/680#discussion_r253398889
+3393,5,1,jholdstock,2019-02-06 14:37:47,https://github.com/decred/politeia/pull/680#discussion_r254295314
+3394,5,1,lukebp,2018-12-18 13:31:53,https://github.com/decred/politeia/pull/644#discussion_r242536736
+3395,5,1,lukebp,2018-12-18 13:37:05,https://github.com/decred/politeia/pull/644#discussion_r242538369
+3396,5,1,lukebp,2018-12-18 13:57:02,https://github.com/decred/politeia/pull/644#discussion_r242545198
+3397,5,1,lukebp,2018-12-18 13:59:16,https://github.com/decred/politeia/pull/644#discussion_r242545957
+3398,5,1,lukebp,2018-12-18 14:07:29,https://github.com/decred/politeia/pull/644#discussion_r242549074
+3399,5,1,thi4go,2018-12-18 21:25:52,https://github.com/decred/politeia/pull/644#discussion_r242711330
+3400,5,1,lukebp,2018-12-18 22:23:08,https://github.com/decred/politeia/pull/644#discussion_r242728357
+3401,5,1,thi4go,2018-12-19 20:04:30,https://github.com/decred/politeia/pull/644#discussion_r243057378
+3402,5,1,lukebp,2018-12-22 18:22:00,https://github.com/decred/politeia/pull/644#discussion_r243743081
+3403,5,1,lukebp,2019-01-08 11:58:21,https://github.com/decred/politeia/pull/644#discussion_r245970579
+3404,5,1,lukebp,2019-01-08 12:27:10,https://github.com/decred/politeia/pull/644#discussion_r245977564
+3405,5,1,lukebp,2019-01-08 12:34:01,https://github.com/decred/politeia/pull/644#discussion_r245979515
+3406,5,1,thi4go,2019-01-08 12:52:42,https://github.com/decred/politeia/pull/644#discussion_r245984535
+3407,5,1,lukebp,2019-01-08 13:33:40,https://github.com/decred/politeia/pull/644#discussion_r245996474
+3408,5,1,thi4go,2019-01-08 15:06:10,https://github.com/decred/politeia/pull/644#discussion_r246029059
+3409,5,1,lukebp,2019-01-08 15:21:17,https://github.com/decred/politeia/pull/644#discussion_r246035325
+3410,5,1,lukebp,2019-01-08 15:28:04,https://github.com/decred/politeia/pull/644#discussion_r246038068
+3411,5,1,lukebp,2019-01-08 15:43:22,https://github.com/decred/politeia/pull/644#discussion_r246044743
+3412,5,1,lukebp,2019-01-08 15:44:20,https://github.com/decred/politeia/pull/644#discussion_r246045176
+3413,5,1,lukebp,2019-01-08 15:52:41,https://github.com/decred/politeia/pull/644#discussion_r246048648
+3414,5,1,thi4go,2019-01-08 23:34:04,https://github.com/decred/politeia/pull/644#discussion_r246202972
+3415,5,1,marcopeereboom,2019-01-28 16:20:06,https://github.com/decred/politeia/pull/644#discussion_r251486551
+3416,5,1,marcopeereboom,2019-01-28 16:21:02,https://github.com/decred/politeia/pull/644#discussion_r251486986
+3417,5,1,marcopeereboom,2019-01-28 16:21:44,https://github.com/decred/politeia/pull/644#discussion_r251487299
+3418,5,1,thi4go,2019-01-29 13:07:45,https://github.com/decred/politeia/pull/644#discussion_r251823862
+3419,5,1,thi4go,2019-01-29 13:19:46,https://github.com/decred/politeia/pull/644#discussion_r251828242
+3420,5,1,thi4go,2019-01-29 13:22:28,https://github.com/decred/politeia/pull/644#discussion_r251829240
+3421,5,1,thi4go,2019-01-29 13:50:22,https://github.com/decred/politeia/pull/644#discussion_r251839615
+3422,5,1,marcopeereboom,2019-01-29 14:14:54,https://github.com/decred/politeia/pull/644#discussion_r251849396
+3423,5,1,thi4go,2019-01-30 14:48:10,https://github.com/decred/politeia/pull/644#discussion_r252286763
+3424,5,1,marcopeereboom,2019-01-30 14:53:44,https://github.com/decred/politeia/pull/644#discussion_r252289138
+3425,5,1,marcopeereboom,2019-01-09 19:11:46,https://github.com/decred/politeia/pull/660#discussion_r246504311
+3426,5,1,marcopeereboom,2019-01-09 19:12:10,https://github.com/decred/politeia/pull/660#discussion_r246504439
+3427,5,1,marcopeereboom,2019-01-09 19:13:45,https://github.com/decred/politeia/pull/660#discussion_r246504896
+3428,5,1,marcopeereboom,2019-01-09 19:14:21,https://github.com/decred/politeia/pull/660#discussion_r246505075
+3429,5,1,marcopeereboom,2019-01-09 19:15:11,https://github.com/decred/politeia/pull/660#discussion_r246505311
+3430,5,1,marcopeereboom,2019-01-09 19:17:36,https://github.com/decred/politeia/pull/660#discussion_r246506100
+3431,5,1,marcopeereboom,2019-01-09 19:18:27,https://github.com/decred/politeia/pull/660#discussion_r246506371
+3432,5,1,lukebp,2019-01-14 14:09:46,https://github.com/decred/politeia/pull/660#discussion_r247504243
+3433,5,1,lukebp,2019-01-14 14:09:51,https://github.com/decred/politeia/pull/660#discussion_r247504299
+3434,5,1,lukebp,2019-01-14 14:09:57,https://github.com/decred/politeia/pull/660#discussion_r247504368
+3435,5,1,lukebp,2019-01-14 14:10:14,https://github.com/decred/politeia/pull/660#discussion_r247504474
+3436,5,1,lukebp,2019-01-14 14:10:23,https://github.com/decred/politeia/pull/660#discussion_r247504528
+3437,5,1,lukebp,2019-01-14 14:12:32,https://github.com/decred/politeia/pull/660#discussion_r247505312
+3438,5,1,lukebp,2019-01-14 14:12:59,https://github.com/decred/politeia/pull/660#discussion_r247505481
+3439,5,1,fernandoabolafio,2019-02-01 18:28:16,https://github.com/decred/politeia/pull/660#discussion_r253151866
+3440,5,1,lukebp,2019-02-01 18:49:27,https://github.com/decred/politeia/pull/660#discussion_r253158748
+3441,5,1,marcopeereboom,2019-02-08 16:04:59,https://github.com/decred/politeia/pull/660#discussion_r255132435
+3442,5,1,marcopeereboom,2019-02-08 16:06:10,https://github.com/decred/politeia/pull/660#discussion_r255132923
+3443,5,1,marcopeereboom,2019-02-08 16:08:45,https://github.com/decred/politeia/pull/660#discussion_r255134146
+3444,5,1,marcopeereboom,2019-02-08 16:10:02,https://github.com/decred/politeia/pull/660#discussion_r255134717
+3445,5,1,marcopeereboom,2019-02-08 16:10:22,https://github.com/decred/politeia/pull/660#discussion_r255134857
+3446,5,1,marcopeereboom,2019-02-08 16:11:59,https://github.com/decred/politeia/pull/660#discussion_r255135493
+3447,5,1,marcopeereboom,2019-02-08 16:15:51,https://github.com/decred/politeia/pull/660#discussion_r255137022
+3448,5,1,marcopeereboom,2019-02-08 16:16:26,https://github.com/decred/politeia/pull/660#discussion_r255137287
+3449,5,1,victorgcramos,2019-02-08 16:34:05,https://github.com/decred/politeia/pull/660#discussion_r255145080
+3450,5,1,lukebp,2019-02-08 16:39:25,https://github.com/decred/politeia/pull/660#discussion_r255147485
+3451,5,1,lukebp,2019-02-08 18:44:35,https://github.com/decred/politeia/pull/660#discussion_r255193090
+3452,5,1,lukebp,2019-02-08 18:45:06,https://github.com/decred/politeia/pull/660#discussion_r255193246
+3453,5,1,lukebp,2019-02-08 18:45:16,https://github.com/decred/politeia/pull/660#discussion_r255193306
+3454,5,1,lukebp,2019-02-08 18:45:22,https://github.com/decred/politeia/pull/660#discussion_r255193347
+3455,5,1,lukebp,2019-02-08 18:45:51,https://github.com/decred/politeia/pull/660#discussion_r255193543
+3456,5,1,lukebp,2019-02-08 18:46:20,https://github.com/decred/politeia/pull/660#discussion_r255193721
+3457,5,1,marcopeereboom,2019-02-08 21:01:06,https://github.com/decred/politeia/pull/660#discussion_r255234082
+3458,5,1,marcopeereboom,2019-02-11 18:09:38,https://github.com/decred/politeia/pull/688#discussion_r255628754
+3459,5,1,marcopeereboom,2019-02-11 18:10:03,https://github.com/decred/politeia/pull/688#discussion_r255628900
+3460,5,1,marcopeereboom,2019-02-11 18:10:27,https://github.com/decred/politeia/pull/688#discussion_r255629047
+3461,5,1,marcopeereboom,2019-02-11 18:12:02,https://github.com/decred/politeia/pull/688#discussion_r255629738
+3462,5,1,dajohi,2019-02-11 18:18:47,https://github.com/decred/politeia/pull/688#discussion_r255632104
+3463,5,1,dajohi,2019-02-11 18:18:59,https://github.com/decred/politeia/pull/688#discussion_r255632174
+3464,5,1,dajohi,2019-02-11 18:19:09,https://github.com/decred/politeia/pull/688#discussion_r255632233
+3465,5,1,dajohi,2019-02-11 18:19:16,https://github.com/decred/politeia/pull/688#discussion_r255632270
+3466,5,1,marcopeereboom,2019-02-11 18:25:28,https://github.com/decred/politeia/pull/688#discussion_r255634586
+3467,5,1,lukebp,2019-02-12 14:46:17,https://github.com/decred/politeia/pull/689#discussion_r255984962
+3468,5,1,lukebp,2019-02-12 14:48:09,https://github.com/decred/politeia/pull/689#discussion_r255985930
+3469,5,1,lukebp,2019-02-12 14:49:57,https://github.com/decred/politeia/pull/689#discussion_r255986780
+3470,5,1,lukebp,2019-02-14 14:03:35,https://github.com/decred/politeia/pull/689#discussion_r256844807
+3471,5,1,lukebp,2019-02-14 14:09:08,https://github.com/decred/politeia/pull/689#discussion_r256846986
+3472,5,1,lukebp,2019-02-14 14:16:57,https://github.com/decred/politeia/pull/689#discussion_r256850105
+3473,5,1,lukebp,2019-02-14 14:21:45,https://github.com/decred/politeia/pull/689#discussion_r256851996
+3474,5,1,lukebp,2019-02-14 14:22:59,https://github.com/decred/politeia/pull/689#discussion_r256852471
+3475,5,1,lukebp,2019-02-14 14:36:32,https://github.com/decred/politeia/pull/689#discussion_r256858151
+3476,5,1,lukebp,2019-02-14 14:50:11,https://github.com/decred/politeia/pull/689#discussion_r256864013
+3477,5,1,dajohi,2019-02-15 20:09:16,https://github.com/decred/politeia/pull/699#discussion_r257375870
+3478,5,1,lukebp,2019-02-15 20:36:50,https://github.com/decred/politeia/pull/699#discussion_r257383329
+3479,5,1,marcopeereboom,2019-02-13 15:18:48,https://github.com/decred/politeia/pull/693#discussion_r256441786
+3480,5,1,marcopeereboom,2019-02-13 15:19:40,https://github.com/decred/politeia/pull/693#discussion_r256442233
+3481,5,1,lukebp,2019-02-13 17:10:18,https://github.com/decred/politeia/pull/693#discussion_r256496699
+3482,5,1,lukebp,2019-02-13 17:11:34,https://github.com/decred/politeia/pull/693#discussion_r256497276
+3483,5,1,dajohi,2019-02-14 15:47:52,https://github.com/decred/politeia/pull/693#discussion_r256890726
+3484,5,1,dajohi,2019-02-14 15:48:56,https://github.com/decred/politeia/pull/693#discussion_r256891241
+3485,5,1,lukebp,2019-02-15 11:56:17,https://github.com/decred/politeia/pull/693#discussion_r257206892
+3486,5,1,lukebp,2019-02-15 11:56:22,https://github.com/decred/politeia/pull/693#discussion_r257206916
+3487,5,1,marcopeereboom,2019-02-18 15:25:23,https://github.com/decred/politeia/pull/693#discussion_r257737725
+3488,5,1,marcopeereboom,2019-02-18 15:26:16,https://github.com/decred/politeia/pull/693#discussion_r257738022
+3489,5,1,lukebp,2019-02-06 23:17:54,https://github.com/decred/politeia/pull/677#discussion_r254492058
+3490,5,1,lukebp,2019-02-06 23:43:02,https://github.com/decred/politeia/pull/677#discussion_r254498217
+3491,5,1,lukebp,2019-02-06 23:46:16,https://github.com/decred/politeia/pull/677#discussion_r254498923
+3492,5,1,lukebp,2019-02-06 23:51:53,https://github.com/decred/politeia/pull/677#discussion_r254500081
+3493,5,1,lukebp,2019-02-06 23:55:46,https://github.com/decred/politeia/pull/677#discussion_r254500971
+3494,5,1,s-ben,2019-02-22 18:35:09,https://github.com/decred/politeia/pull/677#discussion_r259462029
+3495,5,1,s-ben,2019-02-22 18:39:52,https://github.com/decred/politeia/pull/677#discussion_r259463875
+3496,5,1,s-ben,2019-02-22 18:40:25,https://github.com/decred/politeia/pull/677#discussion_r259464085
+3497,5,1,s-ben,2019-02-22 18:42:34,https://github.com/decred/politeia/pull/677#discussion_r259464843
+3498,5,1,s-ben,2019-02-22 18:47:49,https://github.com/decred/politeia/pull/677#discussion_r259466581
+3499,5,1,lukebp,2019-02-24 23:31:33,https://github.com/decred/politeia/pull/677#discussion_r259647765
+3500,5,1,lukebp,2019-02-24 23:37:04,https://github.com/decred/politeia/pull/677#discussion_r259648064
+3501,5,1,marcopeereboom,2019-03-08 14:21:30,https://github.com/decred/politeia/pull/719#discussion_r263792200
+3502,5,1,marcopeereboom,2019-03-08 16:50:38,https://github.com/decred/politeia/pull/719#discussion_r263848558
+3503,5,1,fernandoabolafio,2019-03-08 16:55:48,https://github.com/decred/politeia/pull/719#discussion_r263850442
+3504,5,1,lukebp,2019-03-09 17:47:48,https://github.com/decred/politeia/pull/719#discussion_r264007910
+3505,5,1,marcopeereboom,2019-03-19 18:35:11,https://github.com/decred/politeia/pull/732#discussion_r267040650
+3506,5,1,marcopeereboom,2019-03-19 18:35:43,https://github.com/decred/politeia/pull/732#discussion_r267040862
+3507,5,1,dajohi,2019-03-21 15:42:26,https://github.com/decred/politeia/pull/731#discussion_r267821514
+3508,5,1,thi4go,2019-03-21 15:44:49,https://github.com/decred/politeia/pull/731#discussion_r267822884
+3509,5,1,thi4go,2019-03-21 15:49:12,https://github.com/decred/politeia/pull/731#discussion_r267825338
+3510,5,1,fernandoabolafio,2019-03-07 14:00:10,https://github.com/decred/politeia/pull/710#discussion_r263393447
+3511,5,1,marcopeereboom,2019-03-18 18:10:40,https://github.com/decred/politeia/pull/710#discussion_r266575299
+3512,5,1,marcopeereboom,2019-03-18 18:11:58,https://github.com/decred/politeia/pull/710#discussion_r266575801
+3513,5,1,marcopeereboom,2019-03-18 18:13:20,https://github.com/decred/politeia/pull/710#discussion_r266576363
+3514,5,1,marcopeereboom,2019-03-19 15:04:54,https://github.com/decred/politeia/pull/710#discussion_r266936545
+3515,5,1,lukebp,2019-03-20 15:39:34,https://github.com/decred/politeia/pull/710#discussion_r267405961
+3516,5,1,lukebp,2019-03-20 16:08:54,https://github.com/decred/politeia/pull/710#discussion_r267421218
+3517,5,1,lukebp,2019-03-20 16:11:43,https://github.com/decred/politeia/pull/710#discussion_r267422724
+3518,5,1,lukebp,2019-03-20 16:12:42,https://github.com/decred/politeia/pull/710#discussion_r267423197
+3519,5,1,lukebp,2019-03-20 16:16:26,https://github.com/decred/politeia/pull/710#discussion_r267425059
+3520,5,1,lukebp,2019-03-20 16:35:49,https://github.com/decred/politeia/pull/710#discussion_r267434476
+3521,5,1,lukebp,2019-03-20 17:03:40,https://github.com/decred/politeia/pull/710#discussion_r267447282
+3522,5,1,lukebp,2019-03-20 17:05:12,https://github.com/decred/politeia/pull/710#discussion_r267447929
+3523,5,1,lukebp,2019-03-20 17:14:12,https://github.com/decred/politeia/pull/710#discussion_r267452091
+3524,5,1,lukebp,2019-03-20 17:32:07,https://github.com/decred/politeia/pull/710#discussion_r267460872
+3525,5,1,chappjc,2019-03-25 16:16:12,https://github.com/decred/politeia/pull/750#discussion_r268727215
+3526,5,1,lukebp,2019-02-27 14:24:19,https://github.com/decred/politeia/pull/709#discussion_r260770898
+3527,5,1,thi4go,2019-02-27 18:39:43,https://github.com/decred/politeia/pull/709#discussion_r260887362
+3528,5,1,thi4go,2019-03-11 13:04:02,https://github.com/decred/politeia/pull/709#discussion_r264220715
+3529,5,1,lukebp,2019-03-17 20:31:34,https://github.com/decred/politeia/pull/709#discussion_r266257581
+3530,5,1,lukebp,2019-03-17 20:33:58,https://github.com/decred/politeia/pull/709#discussion_r266257677
+3531,5,1,lukebp,2019-03-17 20:36:38,https://github.com/decred/politeia/pull/709#discussion_r266257802
+3532,5,1,thi4go,2019-03-18 02:27:53,https://github.com/decred/politeia/pull/709#discussion_r266278726
+3533,5,1,thi4go,2019-03-18 02:37:56,https://github.com/decred/politeia/pull/709#discussion_r266279867
+3534,5,1,thi4go,2019-03-21 16:12:43,https://github.com/decred/politeia/pull/709#discussion_r267838289
+3535,5,1,marcopeereboom,2019-03-26 13:26:41,https://github.com/decred/politeia/pull/709#discussion_r269099144
+3536,5,1,marcopeereboom,2019-03-27 18:06:06,https://github.com/decred/politeia/pull/755#discussion_r269700286
+3537,5,1,marcopeereboom,2019-03-27 18:08:01,https://github.com/decred/politeia/pull/755#discussion_r269701119
+3538,5,1,lukebp,2019-03-27 19:58:38,https://github.com/decred/politeia/pull/755#discussion_r269743891
+3539,5,1,lukebp,2019-03-27 19:59:57,https://github.com/decred/politeia/pull/755#discussion_r269744401
+3540,5,1,lukebp,2019-03-25 12:48:40,https://github.com/decred/politeia/pull/735#discussion_r268623334
+3541,5,1,lukebp,2019-03-25 12:53:02,https://github.com/decred/politeia/pull/735#discussion_r268625047
+3542,5,1,lukebp,2019-03-25 12:57:05,https://github.com/decred/politeia/pull/735#discussion_r268626543
+3543,5,1,lukebp,2019-03-25 12:57:41,https://github.com/decred/politeia/pull/735#discussion_r268626803
+3544,5,1,lukebp,2019-03-25 13:03:21,https://github.com/decred/politeia/pull/735#discussion_r268628859
+3545,5,1,lukebp,2019-03-25 13:21:22,https://github.com/decred/politeia/pull/735#discussion_r268635850
+3546,5,1,lukebp,2019-03-25 13:32:25,https://github.com/decred/politeia/pull/735#discussion_r268640750
+3547,5,1,lukebp,2019-03-25 13:35:20,https://github.com/decred/politeia/pull/735#discussion_r268641941
+3548,5,1,alexlyp,2019-03-25 17:24:38,https://github.com/decred/politeia/pull/735#discussion_r268762375
+3549,5,1,tiagoalvesdulce,2019-03-26 13:36:18,https://github.com/decred/politeia/pull/735#discussion_r269103791
+3550,5,1,marcopeereboom,2019-03-26 20:54:45,https://github.com/decred/politeia/pull/735#discussion_r269311204
+3551,5,1,marcopeereboom,2019-03-26 21:00:52,https://github.com/decred/politeia/pull/735#discussion_r269313470
+3552,5,1,marcopeereboom,2019-03-27 17:58:05,https://github.com/decred/politeia/pull/735#discussion_r269696733
+3553,5,1,marcopeereboom,2019-03-27 17:58:34,https://github.com/decred/politeia/pull/735#discussion_r269696982
+3554,5,1,lukebp,2019-03-27 18:49:23,https://github.com/decred/politeia/pull/735#discussion_r269718023
+3555,5,1,lukebp,2019-03-27 19:02:32,https://github.com/decred/politeia/pull/735#discussion_r269723342
+3556,5,1,lukebp,2019-03-27 19:06:12,https://github.com/decred/politeia/pull/735#discussion_r269724676
+3557,5,1,lukebp,2019-03-27 19:14:12,https://github.com/decred/politeia/pull/735#discussion_r269727522
+3558,5,1,lukebp,2019-03-27 19:14:25,https://github.com/decred/politeia/pull/735#discussion_r269727591
+3559,5,1,lukebp,2019-03-27 19:16:48,https://github.com/decred/politeia/pull/735#discussion_r269728428
+3560,5,1,lukebp,2019-03-27 19:20:16,https://github.com/decred/politeia/pull/735#discussion_r269729689
+3561,5,1,lukebp,2019-03-27 19:21:03,https://github.com/decred/politeia/pull/735#discussion_r269729958
+3562,5,1,lukebp,2019-03-27 19:21:19,https://github.com/decred/politeia/pull/735#discussion_r269730047
+3563,5,1,lukebp,2019-03-27 19:22:06,https://github.com/decred/politeia/pull/735#discussion_r269730325
+3564,5,1,lukebp,2019-03-27 19:22:19,https://github.com/decred/politeia/pull/735#discussion_r269730400
+3565,5,1,lukebp,2019-03-27 19:28:56,https://github.com/decred/politeia/pull/735#discussion_r269732885
+3566,5,1,lukebp,2019-03-27 19:29:50,https://github.com/decred/politeia/pull/735#discussion_r269733245
+3567,5,1,lukebp,2019-03-27 19:34:23,https://github.com/decred/politeia/pull/735#discussion_r269734925
+3568,5,1,lukebp,2019-03-27 19:36:03,https://github.com/decred/politeia/pull/735#discussion_r269735457
+3569,5,1,alexlyp,2019-03-27 20:24:58,https://github.com/decred/politeia/pull/735#discussion_r269753931
+3570,5,1,lukebp,2019-03-27 21:21:29,https://github.com/decred/politeia/pull/735#discussion_r269775705
+3571,5,1,thi4go,2019-03-28 11:37:25,https://github.com/decred/politeia/pull/709#discussion_r269960924
+3572,5,1,lukebp,2019-03-25 14:00:05,https://github.com/decred/politeia/pull/744#discussion_r268653538
+3573,5,1,lukebp,2019-03-25 14:07:50,https://github.com/decred/politeia/pull/744#discussion_r268657071
+3574,5,1,lukebp,2019-03-25 14:10:00,https://github.com/decred/politeia/pull/744#discussion_r268658148
+3575,5,1,lukebp,2019-03-25 14:11:05,https://github.com/decred/politeia/pull/744#discussion_r268658682
+3576,5,1,lukebp,2019-03-25 14:11:53,https://github.com/decred/politeia/pull/744#discussion_r268659064
+3577,5,1,lukebp,2019-03-25 14:14:57,https://github.com/decred/politeia/pull/744#discussion_r268660495
+3578,5,1,lukebp,2019-03-25 14:16:00,https://github.com/decred/politeia/pull/744#discussion_r268660963
+3579,5,1,lukebp,2019-03-25 14:21:57,https://github.com/decred/politeia/pull/744#discussion_r268663922
+3580,5,1,lukebp,2019-03-25 14:23:05,https://github.com/decred/politeia/pull/744#discussion_r268664511
+3581,5,1,lukebp,2019-03-25 14:24:45,https://github.com/decred/politeia/pull/744#discussion_r268665410
+3582,5,1,s-ben,2019-03-25 21:47:54,https://github.com/decred/politeia/pull/744#discussion_r268866107
+3583,5,1,s-ben,2019-03-26 00:01:26,https://github.com/decred/politeia/pull/744#discussion_r268900255
+3584,5,1,s-ben,2019-03-26 00:14:38,https://github.com/decred/politeia/pull/744#discussion_r268902572
+3585,5,1,s-ben,2019-03-26 07:39:44,https://github.com/decred/politeia/pull/744#discussion_r268971437
+3586,5,1,s-ben,2019-03-26 08:00:27,https://github.com/decred/politeia/pull/744#discussion_r268977693
+3587,5,1,s-ben,2019-03-27 03:14:15,https://github.com/decred/politeia/pull/744#discussion_r269392187
+3588,5,1,s-ben,2019-03-27 03:14:29,https://github.com/decred/politeia/pull/744#discussion_r269392219
+3589,5,1,s-ben,2019-03-27 03:14:39,https://github.com/decred/politeia/pull/744#discussion_r269392242
+3590,5,1,s-ben,2019-03-27 03:14:56,https://github.com/decred/politeia/pull/744#discussion_r269392271
+3591,5,1,s-ben,2019-03-27 03:15:07,https://github.com/decred/politeia/pull/744#discussion_r269392286
+3592,5,1,lukebp,2019-03-28 12:56:58,https://github.com/decred/politeia/pull/744#discussion_r269986838
+3593,5,1,lukebp,2019-03-28 13:13:07,https://github.com/decred/politeia/pull/744#discussion_r269993508
+3594,5,1,s-ben,2019-03-28 20:55:50,https://github.com/decred/politeia/pull/744#discussion_r270195722
+3595,5,1,fernandoabolafio,2019-03-30 18:38:31,https://github.com/decred/politeia/pull/756#discussion_r270636700

--- a/event_types.csv
+++ b/event_types.csv
@@ -1,6 +1,5 @@
+4,comment
 1,commit
 2,issue
 3,pull_request
-4,comment_on_comment
-5,comment_on_pr
-6,review
+5,review

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ Base.metadata.create_all(engine)
 
 # ----------- Set session variables ---------------
 
-token = 'TOKEN'
+token = 'YOUR-TOKEN'
 username='decred'
 
 

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ Base.metadata.create_all(engine)
 
 # ----------- Set session variables ---------------
 
-token = '58be8c6b6d71c80a48607dcc220f8c7ddd390a6a'
+token = 'TOKEN'
 username='decred'
 
 

--- a/repository_list.csv
+++ b/repository_list.csv
@@ -1,7 +1,1 @@
 1,politeia,decred
-2,dcrd,decred
-3,dcrwallet,decred
-4,dcrdata,decred
-5,dcrbounty,decred
-6,decrediton,decred
-7,dcrdocs,decred


### PR DESCRIPTION
Adds script 'dev_stats.py`, which calculates repo-level stats for each repo ( Closes #6 ). Script outputs:

* Number of commits
* Additions (lines of code added)
* Deletions (lines of code deleted)
* Total lines of code changed

Currently, dev stats are just printed to the command line. 

This commit also adds authentication to GitHub API requests, raising the rate limit from 60 requests/hr to 5,000 requests/hr. 